### PR TITLE
Feat: New Apis 

### DIFF
--- a/.github/workflows/nativeaot-test.yml
+++ b/.github/workflows/nativeaot-test.yml
@@ -26,7 +26,7 @@ jobs:
             ${{ secrets.NETEASE_LOGIN_SECRET }}
             
       - name: Restore
-        run: dotnet restore -r linux-x64 -p:TargetFramework=net10.0
+        run: dotnet restore -r linux-x64 -p:TargetFramework=net10.0 -p:RuntimeIdentifier=linux-x64
   
       - name: Publish with AOT
         run: dotnet publish -c Release -f net10.0 -r linux-x64 --no-restore

--- a/.github/workflows/nativeaot-test.yml
+++ b/.github/workflows/nativeaot-test.yml
@@ -26,10 +26,10 @@ jobs:
             ${{ secrets.NETEASE_LOGIN_SECRET }}
             
       - name: Restore
-        run: dotnet restore -r linux-x64
+        run: dotnet restore -r linux-x64 -f net10.0
   
       - name: Publish with AOT
-        run: dotnet publish -c Release -r linux-x64 --no-restore
+        run: dotnet publish -c Release -r linux-x64 -f net10.0 --no-restore
   
       - name: Run AOT tests
         run: ./HyPlayer.NeteaseProvider.Tests/bin/Release/net9.0/linux-x64/publish/HyPlayer.NeteaseProvider.Tests

--- a/.github/workflows/nativeaot-test.yml
+++ b/.github/workflows/nativeaot-test.yml
@@ -32,4 +32,4 @@ jobs:
         run: dotnet publish -c Release -f net10.0 -r linux-x64 --no-restore
   
       - name: Run AOT tests
-        run: ./HyPlayer.NeteaseProvider.Tests/bin/Release/net9.0/linux-x64/publish/HyPlayer.NeteaseProvider.Tests
+        run: ./HyPlayer.NeteaseProvider.Tests/bin/Release/net10.0/linux-x64/publish/HyPlayer.NeteaseProvider.Tests

--- a/.github/workflows/nativeaot-test.yml
+++ b/.github/workflows/nativeaot-test.yml
@@ -26,7 +26,7 @@ jobs:
             ${{ secrets.NETEASE_LOGIN_SECRET }}
             
       - name: Restore
-        run: dotnet restore -r linux-x64 -f net10.0
+        run: dotnet restore -r linux-x64 -p:TargetFramework=net10.0
   
       - name: Publish with AOT
         run: dotnet publish -c Release -r linux-x64 -f net10.0 --no-restore

--- a/.github/workflows/nativeaot-test.yml
+++ b/.github/workflows/nativeaot-test.yml
@@ -29,7 +29,7 @@ jobs:
         run: dotnet restore -r linux-x64 -p:TargetFramework=net10.0
   
       - name: Publish with AOT
-        run: dotnet publish -c Release -r linux-x64 -f net10.0 --no-restore
+        run: dotnet publish -c Release -f net10.0 -r linux-x64 --no-restore
   
       - name: Run AOT tests
         run: ./HyPlayer.NeteaseProvider.Tests/bin/Release/net9.0/linux-x64/publish/HyPlayer.NeteaseProvider.Tests

--- a/.github/workflows/nativeaot-test.yml
+++ b/.github/workflows/nativeaot-test.yml
@@ -26,10 +26,10 @@ jobs:
             ${{ secrets.NETEASE_LOGIN_SECRET }}
             
       - name: Restore
-        run: dotnet restore -r linux-x64 -p:TargetFramework=net9.0
+        run: dotnet restore -r linux-x64
   
       - name: Publish with AOT
-        run: dotnet publish -c Release -f net9.0 -r linux-x64 --no-restore
+        run: dotnet publish -c Release -r linux-x64 --no-restore
   
       - name: Run AOT tests
         run: ./HyPlayer.NeteaseProvider.Tests/bin/Release/net9.0/linux-x64/publish/HyPlayer.NeteaseProvider.Tests

--- a/EasyDumper/EasyDumper.csproj
+++ b/EasyDumper/EasyDumper.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>

--- a/HyPlayer.NeteaseApi/ApiContracts/Album/AlbumApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Album/AlbumApi.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseApi.ApiContracts.Album;
+﻿using HyPlayer.NeteaseApi.ApiContracts.Album;
 using HyPlayer.NeteaseApi.Bases;
 using HyPlayer.NeteaseApi.Bases.EApiContractBases;
 using HyPlayer.NeteaseApi.Models;

--- a/HyPlayer.NeteaseApi/ApiContracts/Artist/ArtistSongsApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Artist/ArtistSongsApi.cs
@@ -22,7 +22,7 @@ namespace HyPlayer.NeteaseApi.ApiContracts.Artist
     public class ArtistSongsApi : EApiContractBase<ArtistSongsRequest, ArtistSongsResponse, ErrorResultBase,
         ArtistSongsActualRequest>
     {
-        public override string IdentifyRoute => "/api/v2/artist/songs";
+        public override string IdentifyRoute => "/artist/songs";
         public override string Url { get; protected set; } = "https://interfacepc.music.163.com/eapi/v2/artist/songs";
         public override HttpMethod Method => HttpMethod.Post;
 

--- a/HyPlayer.NeteaseApi/ApiContracts/Artist/ArtistSongsApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Artist/ArtistSongsApi.cs
@@ -22,8 +22,8 @@ namespace HyPlayer.NeteaseApi.ApiContracts.Artist
     public class ArtistSongsApi : EApiContractBase<ArtistSongsRequest, ArtistSongsResponse, ErrorResultBase,
         ArtistSongsActualRequest>
     {
-        public override string IdentifyRoute => "/artist/songs";
-        public override string Url { get; protected set; } = "https://interface3.music.163.com/eapi/v2/artist/songs";
+        public override string IdentifyRoute => "/api/v2/artist/songs";
+        public override string Url { get; protected set; } = "https://interfacepc.music.163.com/eapi/v2/artist/songs";
         public override HttpMethod Method => HttpMethod.Post;
 
         public override Task MapRequest(ApiHandlerOption option)
@@ -32,19 +32,6 @@ namespace HyPlayer.NeteaseApi.ApiContracts.Artist
                 ActualRequest = new ArtistSongsActualRequest
                 {
                     Id = Request.ArtistId,
-                    OrderType = Request.OrderType switch
-                    {
-                        ArtistSongsOrderType.Time => "time",
-                        _ => "hot"
-                    },
-                    WorkType = Request.WorkType switch
-                    {
-                        ArtistSongsWorkType.All => 1,
-                        ArtistSongsWorkType.Sing => 5,
-                        ArtistSongsWorkType.Lyric => 6,
-                        ArtistSongsWorkType.Compose => 7,
-                        _ => 1
-                    },
                     Offset = Request.Offset,
                     Limit = Request.Limit
                 };
@@ -57,25 +44,8 @@ namespace HyPlayer.NeteaseApi.ApiContracts.Artist
     public class ArtistSongsActualRequest : EApiActualRequestBase
     {
         [JsonPropertyName("id")] public required string Id { get; set; }
-        [JsonPropertyName("private_cloud")] public bool PrivateCloud => true;
-        [JsonPropertyName("work_type")] public int WorkType = 1;
-        [JsonPropertyName("order")] public string OrderType { get; set; } = "hot";
         [JsonPropertyName("offset")] public int Offset { get; set; } = 0;
         [JsonPropertyName("limit")] public int Limit { get; set; } = 100;
-    }
-
-    public enum ArtistSongsOrderType
-    {
-        Hot,
-        Time
-    }
-
-    public enum ArtistSongsWorkType
-    {
-        All,
-        Sing,
-        Lyric,
-        Compose
     }
 
     public class ArtistSongsRequest : RequestBase
@@ -84,16 +54,6 @@ namespace HyPlayer.NeteaseApi.ApiContracts.Artist
         /// 歌手 ID
         /// </summary>
         public required string ArtistId { get; set; }
-
-        /// <summary>
-        /// 排序类型 hot, time
-        /// </summary>
-        public ArtistSongsOrderType OrderType { get; set; } = ArtistSongsOrderType.Hot;
-
-        /// <summary>
-        ///作品类型
-        /// </summary>
-        public ArtistSongsWorkType WorkType { get; set; } = ArtistSongsWorkType.All;
 
         /// <summary>
         /// 起始位置
@@ -110,6 +70,6 @@ namespace HyPlayer.NeteaseApi.ApiContracts.Artist
     {
         [JsonPropertyName("total")] public int Total { get; set; }
         [JsonPropertyName("more")] public bool HasMore { get; set; }
-        [JsonPropertyName("songs")] public EmittedSongDtoWithPrivilege[]? Songs { get; set; }
+        [JsonPropertyName("songs")] public ArtistSongDto[]? Songs { get; set; }
     }
 }

--- a/HyPlayer.NeteaseApi/ApiContracts/Artist/ArtistSublistApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Artist/ArtistSublistApi.cs
@@ -1,6 +1,5 @@
 ﻿using HyPlayer.NeteaseApi.ApiContracts.Artist;
 using HyPlayer.NeteaseApi.Bases;
-using HyPlayer.NeteaseApi.Bases.ApiContractBases;
 using HyPlayer.NeteaseApi.Models.ResponseModels;
 using System.Text.Json.Serialization;
 using HyPlayer.NeteaseApi.Bases.WeApiContractBases;

--- a/HyPlayer.NeteaseApi/ApiContracts/Artist/ArtistSublistApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Artist/ArtistSublistApi.cs
@@ -1,6 +1,7 @@
 ﻿using HyPlayer.NeteaseApi.ApiContracts.Artist;
 using HyPlayer.NeteaseApi.Bases;
 using HyPlayer.NeteaseApi.Models.ResponseModels;
+using HyPlayer.NeteaseApi.Bases.ApiContractBases;
 using System.Text.Json.Serialization;
 using HyPlayer.NeteaseApi.Bases.WeApiContractBases;
 

--- a/HyPlayer.NeteaseApi/ApiContracts/Artist/ArtistSubscribeApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Artist/ArtistSubscribeApi.cs
@@ -17,7 +17,7 @@ namespace HyPlayer.NeteaseApi.ApiContracts
 namespace HyPlayer.NeteaseApi.ApiContracts.Artist
 {
     public class ArtistSubscribeApi : EApiContractBase<ArtistSubscribeRequest, ArtistSubscribeResponse, ErrorResultBase,
-        ArtistSubscribeActualRequest>
+        ArtistSubscribeActualRequest>, IFakeCheckTokenApi
     {
         public override string ApiPath { get; protected set; } = "/api/artist/sub";
 

--- a/HyPlayer.NeteaseApi/ApiContracts/Artist/ArtistSubscribeApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Artist/ArtistSubscribeApi.cs
@@ -1,0 +1,44 @@
+﻿using HyPlayer.NeteaseApi.ApiContracts.Artist;
+using HyPlayer.NeteaseApi.Bases;
+using HyPlayer.NeteaseApi.Bases.WeApiContractBases;
+
+namespace HyPlayer.NeteaseApi.ApiContracts
+{
+    public static partial class NeteaseApis
+    {
+        /// <summary>
+        /// 艺术家收藏
+        /// </summary>
+        public static ArtistSubscribeApi ArtistSubscribeApi => new();
+    }
+}
+
+namespace HyPlayer.NeteaseApi.ApiContracts.Artist
+{
+    public class ArtistSubscribeApi : WeApiContractBase<ArtistSubscribeRequest, ArtistSubscribeResponse, ErrorResultBase,
+        ArtistSubscribeActualRequest>
+    {
+        public override string IdentifyRoute => "/subscribeartist";
+
+        public override string Url { get; protected set; } = "https://music.163.com/weapi/artist/sub";
+
+        public override HttpMethod Method => HttpMethod.Post;
+
+        public override Task MapRequest(ApiHandlerOption option)
+        {
+            throw new NotImplementedException();
+        }
+    }
+
+    public class ArtistSubscribeRequest : RequestBase
+    {
+    }
+
+    public class ArtistSubscribeResponse : CodedResponseBase
+    {
+    }
+
+    public class ArtistSubscribeActualRequest : WeApiActualRequestBase
+    {
+    }
+}

--- a/HyPlayer.NeteaseApi/ApiContracts/Artist/ArtistSubscribeApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Artist/ArtistSubscribeApi.cs
@@ -1,6 +1,7 @@
 ﻿using HyPlayer.NeteaseApi.ApiContracts.Artist;
 using HyPlayer.NeteaseApi.Bases;
-using HyPlayer.NeteaseApi.Bases.WeApiContractBases;
+using HyPlayer.NeteaseApi.Bases.EApiContractBases;
+using System.Text.Json.Serialization;
 
 namespace HyPlayer.NeteaseApi.ApiContracts
 {
@@ -15,30 +16,42 @@ namespace HyPlayer.NeteaseApi.ApiContracts
 
 namespace HyPlayer.NeteaseApi.ApiContracts.Artist
 {
-    public class ArtistSubscribeApi : WeApiContractBase<ArtistSubscribeRequest, ArtistSubscribeResponse, ErrorResultBase,
+    public class ArtistSubscribeApi : EApiContractBase<ArtistSubscribeRequest, ArtistSubscribeResponse, ErrorResultBase,
         ArtistSubscribeActualRequest>
     {
-        public override string IdentifyRoute => "/subscribeartist";
+        public override string ApiPath { get; protected set; } = "/api/artist/sub";
 
-        public override string Url { get; protected set; } = "https://music.163.com/weapi/artist/sub";
+        public override string IdentifyRoute => "/artist/subscribe";
+
+        public override string Url { get; protected set; } = "https://interface.music.163.com/eapi/artist/";
 
         public override HttpMethod Method => HttpMethod.Post;
 
         public override Task MapRequest(ApiHandlerOption option)
         {
-            throw new NotImplementedException();
+            if (Request is not null)
+            {
+                ActualRequest = new ArtistSubscribeActualRequest
+                {
+                    ArtistId = Request.ArtistId
+                };
+                Url += "sub";
+            }
+            return Task.CompletedTask;
         }
     }
 
     public class ArtistSubscribeRequest : RequestBase
     {
+        public required string ArtistId { get; set; }
     }
 
     public class ArtistSubscribeResponse : CodedResponseBase
     {
     }
 
-    public class ArtistSubscribeActualRequest : WeApiActualRequestBase
+    public class ArtistSubscribeActualRequest : EApiActualRequestBase
     {
+        [JsonPropertyName("artistId")] public required string ArtistId { get; set; }
     }
 }

--- a/HyPlayer.NeteaseApi/ApiContracts/Artist/ArtistSubscribeApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Artist/ArtistSubscribeApi.cs
@@ -23,7 +23,7 @@ namespace HyPlayer.NeteaseApi.ApiContracts.Artist
 
         public override string IdentifyRoute => "/artist/subscribe";
 
-        public override string Url { get; protected set; } = "https://interface.music.163.com/eapi/artist/";
+        public override string Url { get; protected set; } = "https://interface.music.163.com/eapi/artist/sub";
 
         public override HttpMethod Method => HttpMethod.Post;
 
@@ -35,7 +35,6 @@ namespace HyPlayer.NeteaseApi.ApiContracts.Artist
                 {
                     ArtistId = Request.ArtistId
                 };
-                Url += "sub";
             }
             return Task.CompletedTask;
         }

--- a/HyPlayer.NeteaseApi/ApiContracts/Artist/ArtistTopSongApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Artist/ArtistTopSongApi.cs
@@ -95,4 +95,17 @@ namespace HyPlayer.NeteaseApi.ApiContracts.Artist
         [JsonPropertyName("offset")] public int Offset { get; set; } = 0;
         [JsonPropertyName("limit")] public int Limit { get; set; } = 100;
     }
+    public enum ArtistSongsOrderType
+    {
+        Hot,
+        Time
+    }
+
+    public enum ArtistSongsWorkType
+    {
+        All,
+        Sing,
+        Lyric,
+        Compose
+    }
 }

--- a/HyPlayer.NeteaseApi/ApiContracts/Artist/ArtistUnsubscribeApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Artist/ArtistUnsubscribeApi.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace HyPlayer.NeteaseApi.ApiContracts.Artist
+{
+    internal class ArtistUnsubscribeApi
+    {
+    }
+}

--- a/HyPlayer.NeteaseApi/ApiContracts/Artist/ArtistUnsubscribeApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Artist/ArtistUnsubscribeApi.cs
@@ -45,7 +45,7 @@ namespace HyPlayer.NeteaseApi.ApiContracts.Artist
         /// <summary>
         /// Array of artist ids. Will be converted to a JSON array string in the request, e.g. new long[] { 35374786 } -> "[35374786]"
         /// </summary>
-        public required string[] ArtistIds { get; set; }
+        public required long[] ArtistIds { get; set; }
     }
 
     public class ArtistUnsubscribeResponse : CodedResponseBase

--- a/HyPlayer.NeteaseApi/ApiContracts/Artist/ArtistUnsubscribeApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Artist/ArtistUnsubscribeApi.cs
@@ -1,10 +1,59 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
+﻿using HyPlayer.NeteaseApi.Bases;
+using HyPlayer.NeteaseApi.Bases.EApiContractBases;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using HyPlayer.NeteaseApi.ApiContracts.Artist;
+
+namespace HyPlayer.NeteaseApi.ApiContracts
+{
+    public static partial class NeteaseApis
+    {
+        public static ArtistUnsubscribeApi ArtistUnsubscribeApi => new();
+    }
+}
 
 namespace HyPlayer.NeteaseApi.ApiContracts.Artist
 {
-    internal class ArtistUnsubscribeApi
+    public class ArtistUnsubscribeApi : EApiContractBase<ArtistUnsubscribeRequest, ArtistUnsubscribeResponse, ErrorResultBase,
+        ArtistUnsubscribeActualRequest>
     {
+        public override string ApiPath { get; protected set; } = "/api/artist/unsub";
+
+        public override string IdentifyRoute => "/artist/unsub";
+
+        public override string Url { get; protected set; } = "https://interface.music.163.com/eapi/artist/";
+
+        public override HttpMethod Method => HttpMethod.Post;
+
+        public override Task MapRequest(ApiHandlerOption option)
+        {
+            if (Request is not null)
+            {
+                ActualRequest = new ArtistUnsubscribeActualRequest
+                {
+                    // serialize C# array of ids to JSON array string expected by the API
+                    ArtistIds = JsonSerializer.Serialize(Request.ArtistIds)
+                };
+                Url += "unsub";
+            }
+            return Task.CompletedTask;
+        }
+    }
+
+    public class ArtistUnsubscribeRequest : RequestBase
+    {
+        /// <summary>
+        /// Array of artist ids. Will be converted to a JSON array string in the request, e.g. new long[] { 35374786 } -> "[35374786]"
+        /// </summary>
+        public required string[] ArtistIds { get; set; }
+    }
+
+    public class ArtistUnsubscribeResponse : CodedResponseBase
+    {
+    }
+
+    public class ArtistUnsubscribeActualRequest : EApiActualRequestBase
+    {
+        [JsonPropertyName("artistIds")] public required string ArtistIds { get; set; }
     }
 }

--- a/HyPlayer.NeteaseApi/ApiContracts/Cloud/NeteaseUploadLoadBalancerGetApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Cloud/NeteaseUploadLoadBalancerGetApi.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseApi.ApiContracts.Cloud;
+﻿using HyPlayer.NeteaseApi.ApiContracts.Cloud;
 using HyPlayer.NeteaseApi.Bases;
 using HyPlayer.NeteaseApi.Bases.RawApiContractBases;
 using System.Text.Json.Serialization;

--- a/HyPlayer.NeteaseApi/ApiContracts/Comment/CommentLikeApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Comment/CommentLikeApi.cs
@@ -1,6 +1,5 @@
 ﻿using HyPlayer.NeteaseApi.ApiContracts.Comment;
 using HyPlayer.NeteaseApi.Bases;
-using HyPlayer.NeteaseApi.Bases.ApiContractBases;
 using HyPlayer.NeteaseApi.Extensions;
 using HyPlayer.NeteaseApi.Models;
 using System.Text.Json.Serialization;

--- a/HyPlayer.NeteaseApi/ApiContracts/Comment/CommentLikeApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Comment/CommentLikeApi.cs
@@ -2,6 +2,7 @@
 using HyPlayer.NeteaseApi.Bases;
 using HyPlayer.NeteaseApi.Extensions;
 using HyPlayer.NeteaseApi.Models;
+using HyPlayer.NeteaseApi.Bases.ApiContractBases;
 using System.Text.Json.Serialization;
 using HyPlayer.NeteaseApi.Bases.WeApiContractBases;
 

--- a/HyPlayer.NeteaseApi/ApiContracts/DjChannel/DjChannelSubscribeApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/DjChannel/DjChannelSubscribeApi.cs
@@ -1,0 +1,46 @@
+﻿using HyPlayer.NeteaseApi.Bases;
+using HyPlayer.NeteaseApi.Bases.EApiContractBases;
+using System.Text.Json.Serialization;
+
+namespace HyPlayer.NeteaseApi.ApiContracts.DjChannel
+{
+    public class DjChannelSubscribeApi : EApiContractBase<DjChannelSubscribeRequest, DjChannelSubscribeResponse, ErrorResultBase, DjChannelSubscribeActualRequest>
+    {
+        public override string ApiPath { get; protected set; } = " /api/djradio/sub";
+
+        public override string IdentifyRoute => "/djchannel/subscribe";
+
+        public override string Url { get; protected set; } = "https://interface.music.163.com/eapi/djradio/";
+
+        public override HttpMethod Method => HttpMethod.Post;
+
+        public override Task MapRequest(ApiHandlerOption option)
+        {
+            if (Request is not null)
+            {
+                ActualRequest = new DjChannelSubscribeActualRequest
+                {
+                    Id = Request.Id
+                };
+                Url += Request.IsSubscribe ? "sub" : "unsub";
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    public class DjChannelSubscribeActualRequest : EApiActualRequestBase
+    {
+        [JsonPropertyName("id")] public required string Id { get; set; }
+    }
+
+    public class DjChannelSubscribeResponse : CodedResponseBase
+    {
+    }
+
+    public class DjChannelSubscribeRequest : RequestBase
+    {
+        public required string Id { get; set; }
+        public bool IsSubscribe { get; set; }
+    }
+}

--- a/HyPlayer.NeteaseApi/ApiContracts/DjChannel/DjChannelSubscribeApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/DjChannel/DjChannelSubscribeApi.cs
@@ -1,6 +1,15 @@
 ﻿using HyPlayer.NeteaseApi.Bases;
 using HyPlayer.NeteaseApi.Bases.EApiContractBases;
 using System.Text.Json.Serialization;
+using HyPlayer.NeteaseApi.ApiContracts.DjChannel;
+
+namespace HyPlayer.NeteaseApi.ApiContracts
+{
+    public static partial class NeteaseApis
+    {
+        public static DjChannelSubscribeApi DjChannelSubscribeApi => new();
+    }
+}
 
 namespace HyPlayer.NeteaseApi.ApiContracts.DjChannel
 {

--- a/HyPlayer.NeteaseApi/ApiContracts/ListenTogether/Dual/ListenTogetherEndApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/ListenTogether/Dual/ListenTogetherEndApi.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseApi.ApiContracts.ListenTogether.Dual;
+﻿using HyPlayer.NeteaseApi.ApiContracts.ListenTogether.Dual;
 using HyPlayer.NeteaseApi.Bases;
 using HyPlayer.NeteaseApi.Bases.EApiContractBases;
 using System.Text.Json.Serialization;

--- a/HyPlayer.NeteaseApi/ApiContracts/ListenTogether/Dual/ListenTogetherHeartbeatApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/ListenTogether/Dual/ListenTogetherHeartbeatApi.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseApi.ApiContracts.ListenTogether.Dual;
+﻿using HyPlayer.NeteaseApi.ApiContracts.ListenTogether.Dual;
 using HyPlayer.NeteaseApi.Bases;
 using HyPlayer.NeteaseApi.Bases.EApiContractBases;
 using System.Text.Json.Serialization;

--- a/HyPlayer.NeteaseApi/ApiContracts/ListenTogether/Dual/ListenTogetherInvitationAcceptApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/ListenTogether/Dual/ListenTogetherInvitationAcceptApi.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseApi.ApiContracts.ListenTogether;
+﻿using HyPlayer.NeteaseApi.ApiContracts.ListenTogether;
 using HyPlayer.NeteaseApi.ApiContracts.ListenTogether.Dual;
 using HyPlayer.NeteaseApi.Bases;
 using HyPlayer.NeteaseApi.Bases.EApiContractBases;

--- a/HyPlayer.NeteaseApi/ApiContracts/ListenTogether/Dual/ListenTogetherPlayCommandApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/ListenTogether/Dual/ListenTogetherPlayCommandApi.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseApi.ApiContracts.ListenTogether;
+﻿using HyPlayer.NeteaseApi.ApiContracts.ListenTogether;
 using HyPlayer.NeteaseApi.ApiContracts.ListenTogether.Dual;
 using HyPlayer.NeteaseApi.Bases;
 using HyPlayer.NeteaseApi.Bases.EApiContractBases;

--- a/HyPlayer.NeteaseApi/ApiContracts/ListenTogether/Dual/ListenTogetherRoomCheckApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/ListenTogether/Dual/ListenTogetherRoomCheckApi.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseApi.ApiContracts.ListenTogether;
+﻿using HyPlayer.NeteaseApi.ApiContracts.ListenTogether;
 using HyPlayer.NeteaseApi.Bases;
 using HyPlayer.NeteaseApi.Bases.EApiContractBases;
 using System.Text.Json.Serialization;

--- a/HyPlayer.NeteaseApi/ApiContracts/ListenTogether/Dual/ListenTogetherRoomCreate.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/ListenTogether/Dual/ListenTogetherRoomCreate.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseApi.ApiContracts.ListenTogether.Dual;
+﻿using HyPlayer.NeteaseApi.ApiContracts.ListenTogether.Dual;
 using HyPlayer.NeteaseApi.Bases;
 using HyPlayer.NeteaseApi.Bases.EApiContractBases;
 using System.Text.Json.Serialization;

--- a/HyPlayer.NeteaseApi/ApiContracts/ListenTogether/Dual/ListenTogetherStatusApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/ListenTogether/Dual/ListenTogetherStatusApi.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseApi.ApiContracts.ListenTogether;
+﻿using HyPlayer.NeteaseApi.ApiContracts.ListenTogether;
 using HyPlayer.NeteaseApi.ApiContracts.ListenTogether.Dual;
 using HyPlayer.NeteaseApi.Bases;
 using HyPlayer.NeteaseApi.Bases.EApiContractBases;

--- a/HyPlayer.NeteaseApi/ApiContracts/ListenTogether/Dual/ListenTogetherSyncListCommandApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/ListenTogether/Dual/ListenTogetherSyncListCommandApi.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseApi.ApiContracts.ListenTogether;
+﻿using HyPlayer.NeteaseApi.ApiContracts.ListenTogether;
 using HyPlayer.NeteaseApi.Bases;
 using HyPlayer.NeteaseApi.Bases.EApiContractBases;
 using System.Text.Json;

--- a/HyPlayer.NeteaseApi/ApiContracts/ListenTogether/Dual/ListenTogetherSyncListGetApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/ListenTogether/Dual/ListenTogetherSyncListGetApi.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseApi.ApiContracts.ListenTogether;
+﻿using HyPlayer.NeteaseApi.ApiContracts.ListenTogether;
 using HyPlayer.NeteaseApi.Bases;
 using HyPlayer.NeteaseApi.Bases.EApiContractBases;
 using System.Text.Json.Serialization;

--- a/HyPlayer.NeteaseApi/ApiContracts/PersonalFM/AiDjContentRcmdInfo.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/PersonalFM/AiDjContentRcmdInfo.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseApi.ApiContracts.PersonalFM;
+﻿using HyPlayer.NeteaseApi.ApiContracts.PersonalFM;
 using HyPlayer.NeteaseApi.Bases;
 using HyPlayer.NeteaseApi.Bases.EApiContractBases;
 using HyPlayer.NeteaseApi.Models.ResponseModels;

--- a/HyPlayer.NeteaseApi/ApiContracts/PersonalFM/PersonalFmTrashApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/PersonalFM/PersonalFmTrashApi.cs
@@ -1,5 +1,6 @@
 using HyPlayer.NeteaseApi.ApiContracts.PersonalFM;
 using HyPlayer.NeteaseApi.Bases;
+using HyPlayer.NeteaseApi.Bases.ApiContractBases;
 using System.Text.Json.Serialization;
 using HyPlayer.NeteaseApi.Bases.WeApiContractBases;
 

--- a/HyPlayer.NeteaseApi/ApiContracts/PersonalFM/PersonalFmTrashApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/PersonalFM/PersonalFmTrashApi.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseApi.ApiContracts.PersonalFM;
+﻿using HyPlayer.NeteaseApi.ApiContracts.PersonalFM;
 using HyPlayer.NeteaseApi.Bases;
 using HyPlayer.NeteaseApi.Bases.ApiContractBases;
 using System.Text.Json.Serialization;

--- a/HyPlayer.NeteaseApi/ApiContracts/PersonalFM/PersonalFmTrashApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/PersonalFM/PersonalFmTrashApi.cs
@@ -1,6 +1,5 @@
 using HyPlayer.NeteaseApi.ApiContracts.PersonalFM;
 using HyPlayer.NeteaseApi.Bases;
-using HyPlayer.NeteaseApi.Bases.ApiContractBases;
 using System.Text.Json.Serialization;
 using HyPlayer.NeteaseApi.Bases.WeApiContractBases;
 

--- a/HyPlayer.NeteaseApi/ApiContracts/Playlist/LikelistApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Playlist/LikelistApi.cs
@@ -1,6 +1,5 @@
 ﻿using HyPlayer.NeteaseApi.ApiContracts.Playlist;
 using HyPlayer.NeteaseApi.Bases;
-using HyPlayer.NeteaseApi.Bases.ApiContractBases;
 using System.Text.Json.Serialization;
 using HyPlayer.NeteaseApi.Bases.WeApiContractBases;
 
@@ -40,7 +39,7 @@ namespace HyPlayer.NeteaseApi.ApiContracts.Playlist
     public class LikelistRequest : RequestBase
     {
         /// <summary>
-        /// 用户 ID
+        /// 歌单 ID
         /// </summary>
         public required string Uid { get; set; }
     }

--- a/HyPlayer.NeteaseApi/ApiContracts/Playlist/LikelistApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Playlist/LikelistApi.cs
@@ -1,5 +1,6 @@
 ﻿using HyPlayer.NeteaseApi.ApiContracts.Playlist;
 using HyPlayer.NeteaseApi.Bases;
+using HyPlayer.NeteaseApi.Bases.ApiContractBases;
 using System.Text.Json.Serialization;
 using HyPlayer.NeteaseApi.Bases.WeApiContractBases;
 

--- a/HyPlayer.NeteaseApi/ApiContracts/Playlist/LikelistApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Playlist/LikelistApi.cs
@@ -40,7 +40,7 @@ namespace HyPlayer.NeteaseApi.ApiContracts.Playlist
     public class LikelistRequest : RequestBase
     {
         /// <summary>
-        /// 歌单 ID
+        /// 用户 ID
         /// </summary>
         public required string Uid { get; set; }
     }

--- a/HyPlayer.NeteaseApi/ApiContracts/Playlist/PlaylistCreateApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Playlist/PlaylistCreateApi.cs
@@ -1,6 +1,5 @@
 ﻿using HyPlayer.NeteaseApi.ApiContracts.Playlist;
 using HyPlayer.NeteaseApi.Bases;
-using HyPlayer.NeteaseApi.Bases.ApiContractBases;
 using HyPlayer.NeteaseApi.Bases.EApiContractBases;
 using System.Text.Json.Serialization;
 using HyPlayer.NeteaseApi.Bases.WeApiContractBases;

--- a/HyPlayer.NeteaseApi/ApiContracts/Playlist/PlaylistCreateApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Playlist/PlaylistCreateApi.cs
@@ -1,6 +1,7 @@
 ﻿using HyPlayer.NeteaseApi.ApiContracts.Playlist;
 using HyPlayer.NeteaseApi.Bases;
 using HyPlayer.NeteaseApi.Bases.EApiContractBases;
+using HyPlayer.NeteaseApi.Bases.ApiContractBases;
 using System.Text.Json.Serialization;
 using HyPlayer.NeteaseApi.Bases.WeApiContractBases;
 

--- a/HyPlayer.NeteaseApi/ApiContracts/Playlist/PlaylistDeleteApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Playlist/PlaylistDeleteApi.cs
@@ -1,6 +1,5 @@
 ﻿using HyPlayer.NeteaseApi.ApiContracts.Playlist;
 using HyPlayer.NeteaseApi.Bases;
-using HyPlayer.NeteaseApi.Bases.ApiContractBases;
 using System.Text.Json.Serialization;
 using HyPlayer.NeteaseApi.Bases.WeApiContractBases;
 

--- a/HyPlayer.NeteaseApi/ApiContracts/Playlist/PlaylistDeleteApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Playlist/PlaylistDeleteApi.cs
@@ -1,5 +1,6 @@
 ﻿using HyPlayer.NeteaseApi.ApiContracts.Playlist;
 using HyPlayer.NeteaseApi.Bases;
+using HyPlayer.NeteaseApi.Bases.ApiContractBases;
 using System.Text.Json.Serialization;
 using HyPlayer.NeteaseApi.Bases.WeApiContractBases;
 

--- a/HyPlayer.NeteaseApi/ApiContracts/Playlist/PlaylistSubscribeApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Playlist/PlaylistSubscribeApi.cs
@@ -1,6 +1,5 @@
 ﻿using HyPlayer.NeteaseApi.ApiContracts.Playlist;
 using HyPlayer.NeteaseApi.Bases;
-using HyPlayer.NeteaseApi.Bases.ApiContractBases;
 using System.Text.Json.Serialization;
 using HyPlayer.NeteaseApi.Bases.WeApiContractBases;
 

--- a/HyPlayer.NeteaseApi/ApiContracts/Playlist/PlaylistSubscribeApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Playlist/PlaylistSubscribeApi.cs
@@ -1,5 +1,6 @@
 ﻿using HyPlayer.NeteaseApi.ApiContracts.Playlist;
 using HyPlayer.NeteaseApi.Bases;
+using HyPlayer.NeteaseApi.Bases.ApiContractBases;
 using System.Text.Json.Serialization;
 using HyPlayer.NeteaseApi.Bases.WeApiContractBases;
 

--- a/HyPlayer.NeteaseApi/ApiContracts/Playlist/PlaylistTracksEditApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Playlist/PlaylistTracksEditApi.cs
@@ -1,6 +1,5 @@
 ﻿using HyPlayer.NeteaseApi.ApiContracts.Playlist;
 using HyPlayer.NeteaseApi.Bases;
-using HyPlayer.NeteaseApi.Bases.ApiContractBases;
 using System.Text.Json.Serialization;
 using HyPlayer.NeteaseApi.Bases.WeApiContractBases;
 

--- a/HyPlayer.NeteaseApi/ApiContracts/Playlist/PlaylistTracksEditApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Playlist/PlaylistTracksEditApi.cs
@@ -1,5 +1,6 @@
 ﻿using HyPlayer.NeteaseApi.ApiContracts.Playlist;
 using HyPlayer.NeteaseApi.Bases;
+using HyPlayer.NeteaseApi.Bases.ApiContractBases;
 using System.Text.Json.Serialization;
 using HyPlayer.NeteaseApi.Bases.WeApiContractBases;
 

--- a/HyPlayer.NeteaseApi/ApiContracts/Playlist/PlaylistTracksGetApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Playlist/PlaylistTracksGetApi.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseApi.ApiContracts.Playlist;
+﻿using HyPlayer.NeteaseApi.ApiContracts.Playlist;
 using HyPlayer.NeteaseApi.Bases;
 using HyPlayer.NeteaseApi.Bases.EApiContractBases;
 using System.Text.Json.Serialization;

--- a/HyPlayer.NeteaseApi/ApiContracts/Playlist/PlaymodeIntelligenceListApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Playlist/PlaymodeIntelligenceListApi.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseApi.ApiContracts.Playlist;
+﻿using HyPlayer.NeteaseApi.ApiContracts.Playlist;
 using HyPlayer.NeteaseApi.Bases;
 using HyPlayer.NeteaseApi.Bases.EApiContractBases;
 using HyPlayer.NeteaseApi.Models.ResponseModels;

--- a/HyPlayer.NeteaseApi/ApiContracts/Recommend/RecommendPlaylistsApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Recommend/RecommendPlaylistsApi.cs
@@ -1,5 +1,6 @@
 ﻿using HyPlayer.NeteaseApi.ApiContracts.Recommend;
 using HyPlayer.NeteaseApi.Bases;
+using HyPlayer.NeteaseApi.Bases.ApiContractBases;
 using HyPlayer.NeteaseApi.Models.ResponseModels;
 using System.Text.Json.Serialization;
 using HyPlayer.NeteaseApi.Bases.WeApiContractBases;

--- a/HyPlayer.NeteaseApi/ApiContracts/Recommend/RecommendPlaylistsApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Recommend/RecommendPlaylistsApi.cs
@@ -1,6 +1,5 @@
 ﻿using HyPlayer.NeteaseApi.ApiContracts.Recommend;
 using HyPlayer.NeteaseApi.Bases;
-using HyPlayer.NeteaseApi.Bases.ApiContractBases;
 using HyPlayer.NeteaseApi.Models.ResponseModels;
 using System.Text.Json.Serialization;
 using HyPlayer.NeteaseApi.Bases.WeApiContractBases;

--- a/HyPlayer.NeteaseApi/ApiContracts/Recommend/RecommendResourceApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Recommend/RecommendResourceApi.cs
@@ -1,5 +1,6 @@
 ﻿using HyPlayer.NeteaseApi.ApiContracts.Recommend;
 using HyPlayer.NeteaseApi.Bases;
+using HyPlayer.NeteaseApi.Bases.ApiContractBases;
 using HyPlayer.NeteaseApi.Models.ResponseModels;
 using System.Text.Json.Serialization;
 using HyPlayer.NeteaseApi.Bases.WeApiContractBases;

--- a/HyPlayer.NeteaseApi/ApiContracts/Recommend/RecommendResourceApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Recommend/RecommendResourceApi.cs
@@ -1,6 +1,5 @@
 ﻿using HyPlayer.NeteaseApi.ApiContracts.Recommend;
 using HyPlayer.NeteaseApi.Bases;
-using HyPlayer.NeteaseApi.Bases.ApiContractBases;
 using HyPlayer.NeteaseApi.Models.ResponseModels;
 using System.Text.Json.Serialization;
 using HyPlayer.NeteaseApi.Bases.WeApiContractBases;

--- a/HyPlayer.NeteaseApi/ApiContracts/Recommend/RecommendSongs.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Recommend/RecommendSongs.cs
@@ -1,5 +1,6 @@
 ﻿using HyPlayer.NeteaseApi.ApiContracts.Recommend;
 using HyPlayer.NeteaseApi.Bases;
+using HyPlayer.NeteaseApi.Bases.ApiContractBases;
 using HyPlayer.NeteaseApi.Models.ResponseModels;
 using System.Text.Json.Serialization;
 using HyPlayer.NeteaseApi.Bases.WeApiContractBases;

--- a/HyPlayer.NeteaseApi/ApiContracts/Recommend/RecommendSongs.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Recommend/RecommendSongs.cs
@@ -1,6 +1,5 @@
 ﻿using HyPlayer.NeteaseApi.ApiContracts.Recommend;
 using HyPlayer.NeteaseApi.Bases;
-using HyPlayer.NeteaseApi.Bases.ApiContractBases;
 using HyPlayer.NeteaseApi.Models.ResponseModels;
 using System.Text.Json.Serialization;
 using HyPlayer.NeteaseApi.Bases.WeApiContractBases;

--- a/HyPlayer.NeteaseApi/ApiContracts/Recommend/SearchApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Recommend/SearchApi.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseApi.ApiContracts.Recommend;
+﻿using HyPlayer.NeteaseApi.ApiContracts.Recommend;
 using HyPlayer.NeteaseApi.Bases;
 using HyPlayer.NeteaseApi.Bases.EApiContractBases;
 using HyPlayer.NeteaseApi.Models;

--- a/HyPlayer.NeteaseApi/ApiContracts/Recommend/SearchSuggestionApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Recommend/SearchSuggestionApi.cs
@@ -1,7 +1,9 @@
 ﻿using HyPlayer.NeteaseApi.ApiContracts.Recommend;
 using HyPlayer.NeteaseApi.Bases;
 using System.Text.Json.Serialization;
+using HyPlayer.NeteaseApi.Bases.ApiContractBases;
 using HyPlayer.NeteaseApi.Bases.WeApiContractBases;
+
 
 namespace HyPlayer.NeteaseApi.ApiContracts
 {

--- a/HyPlayer.NeteaseApi/ApiContracts/Recommend/SearchSuggestionApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Recommend/SearchSuggestionApi.cs
@@ -1,6 +1,5 @@
 ﻿using HyPlayer.NeteaseApi.ApiContracts.Recommend;
 using HyPlayer.NeteaseApi.Bases;
-using HyPlayer.NeteaseApi.Bases.ApiContractBases;
 using System.Text.Json.Serialization;
 using HyPlayer.NeteaseApi.Bases.WeApiContractBases;
 

--- a/HyPlayer.NeteaseApi/ApiContracts/Song/MusicFirstListenInfoApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Song/MusicFirstListenInfoApi.cs
@@ -1,5 +1,6 @@
 using HyPlayer.NeteaseApi.ApiContracts.Song;
 using HyPlayer.NeteaseApi.Bases;
+using HyPlayer.NeteaseApi.Bases.ApiContractBases;
 using System.Text.Json.Serialization;
 using HyPlayer.NeteaseApi.Bases.WeApiContractBases;
 

--- a/HyPlayer.NeteaseApi/ApiContracts/Song/MusicFirstListenInfoApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Song/MusicFirstListenInfoApi.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseApi.ApiContracts.Song;
+﻿using HyPlayer.NeteaseApi.ApiContracts.Song;
 using HyPlayer.NeteaseApi.Bases;
 using HyPlayer.NeteaseApi.Bases.ApiContractBases;
 using System.Text.Json.Serialization;

--- a/HyPlayer.NeteaseApi/ApiContracts/Song/MusicFirstListenInfoApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Song/MusicFirstListenInfoApi.cs
@@ -1,6 +1,5 @@
 using HyPlayer.NeteaseApi.ApiContracts.Song;
 using HyPlayer.NeteaseApi.Bases;
-using HyPlayer.NeteaseApi.Bases.ApiContractBases;
 using System.Text.Json.Serialization;
 using HyPlayer.NeteaseApi.Bases.WeApiContractBases;
 

--- a/HyPlayer.NeteaseApi/ApiContracts/Song/SongChorusApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Song/SongChorusApi.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseApi.ApiContracts.Song;
+﻿using HyPlayer.NeteaseApi.ApiContracts.Song;
 using HyPlayer.NeteaseApi.Bases;
 using HyPlayer.NeteaseApi.Bases.EApiContractBases;
 using System.Text.Json.Serialization;

--- a/HyPlayer.NeteaseApi/ApiContracts/User/UserFollowApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/User/UserFollowApi.cs
@@ -12,7 +12,7 @@ namespace HyPlayer.NeteaseApi.ApiContracts
 
 namespace HyPlayer.NeteaseApi.ApiContracts.User
 {
-    public class UserFollowApi : EApiContractBase<UserFollowRequest, UserFollowResponse, ErrorResultBase, UserFollowActualRequestBase>
+    public class UserFollowApi : EApiContractBase<UserFollowRequest, UserFollowResponse, ErrorResultBase, UserFollowActualRequestBase>, IFakeCheckTokenApi
     {
         public override string ApiPath { get; protected set; } = "/user/follow";
 

--- a/HyPlayer.NeteaseApi/ApiContracts/User/UserFollowApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/User/UserFollowApi.cs
@@ -14,20 +14,23 @@ namespace HyPlayer.NeteaseApi.ApiContracts.User
 {
     public class UserFollowApi : EApiContractBase<UserFollowRequest, UserFollowResponse, ErrorResultBase, UserFollowActualRequestBase>, IFakeCheckTokenApi
     {
-        public override string ApiPath { get; protected set; } = "/user/follow";
+        public override string ApiPath { get; protected set; } = "/api/user/follow/";
 
         public override string IdentifyRoute => "/user/follow";
 
-        public override string Url { get; protected set; } = "https://interfacepc.music.163.com/eapi/user/";
+        public override string Url { get; protected set; } = "https://interfacepc.music.163.com/eapi/user/follow/";
 
         public override HttpMethod Method => HttpMethod.Post;
 
         public override Task MapRequest(ApiHandlerOption option)
         {
             ActualRequest = new UserFollowActualRequestBase();
-
-            Url += Request.IsFollow ? "follow/" : "delfollow/";
-            Url += Request.Id;
+            if (Request is not null)
+            {
+                Url += Request.Id;
+                ApiPath += Request.Id;
+            }
+                
 
             return Task.CompletedTask;
         }
@@ -44,7 +47,5 @@ namespace HyPlayer.NeteaseApi.ApiContracts.User
     public class UserFollowRequest : RequestBase
     {
         public required string Id { get; set; }
-
-        public bool IsFollow { get; set; }
     }
 }

--- a/HyPlayer.NeteaseApi/ApiContracts/User/UserFollowApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/User/UserFollowApi.cs
@@ -1,0 +1,50 @@
+﻿using HyPlayer.NeteaseApi.Bases;
+using HyPlayer.NeteaseApi.Bases.EApiContractBases;
+using HyPlayer.NeteaseApi.ApiContracts.User;
+
+namespace HyPlayer.NeteaseApi.ApiContracts
+{
+    public static partial class NeteaseApis
+    {
+        public static UserFollowApi UserFollowApi => new();
+    }
+}
+
+namespace HyPlayer.NeteaseApi.ApiContracts.User
+{
+    public class UserFollowApi : EApiContractBase<UserFollowRequest, UserFollowResponse, ErrorResultBase, UserFollowActualRequestBase>
+    {
+        public override string ApiPath { get; protected set; } = "/user/follow";
+
+        public override string IdentifyRoute => "/user/follow";
+
+        public override string Url { get; protected set; } = "https://interfacepc.music.163.com/eapi/user/";
+
+        public override HttpMethod Method => HttpMethod.Post;
+
+        public override Task MapRequest(ApiHandlerOption option)
+        {
+            ActualRequest = new UserFollowActualRequestBase();
+
+            Url += Request.IsFollow ? "follow/" : "delfollow/";
+            Url += Request.Id;
+
+            return Task.CompletedTask;
+        }
+    }
+
+    public class UserFollowActualRequestBase : EApiActualRequestBase
+    {
+    }
+
+    public class UserFollowResponse : CodedResponseBase
+    {
+    }
+
+    public class UserFollowRequest : RequestBase
+    {
+        public required string Id { get; set; }
+
+        public bool IsFollow { get; set; }
+    }
+}

--- a/HyPlayer.NeteaseApi/ApiContracts/User/UserPlaylistApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/User/UserPlaylistApi.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseApi.ApiContracts.User;
+﻿using HyPlayer.NeteaseApi.ApiContracts.User;
 using HyPlayer.NeteaseApi.Bases;
 using HyPlayer.NeteaseApi.Bases.EApiContractBases;
 using HyPlayer.NeteaseApi.Models.ResponseModels;

--- a/HyPlayer.NeteaseApi/ApiContracts/User/UserUnfollowApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/User/UserUnfollowApi.cs
@@ -1,0 +1,50 @@
+﻿using HyPlayer.NeteaseApi.Bases;
+using HyPlayer.NeteaseApi.Bases.EApiContractBases;
+using HyPlayer.NeteaseApi.ApiContracts.User;
+
+namespace HyPlayer.NeteaseApi.ApiContracts
+{
+    public static partial class NeteaseApis
+    {
+        public static UserUnfollowApi UserUnfollowApi => new();
+    }
+}
+
+namespace HyPlayer.NeteaseApi.ApiContracts.User
+{
+    public class UserUnfollowApi : EApiContractBase<UserUnfollowRequest, UserUnfollowResponse, ErrorResultBase, UserUnfollowActualRequestBase>, IFakeCheckTokenApi
+    {
+        public override string ApiPath { get; protected set; } = "/api/user/delfollow/";
+
+        public override string IdentifyRoute => "/user/delfollow";
+
+        public override string Url { get; protected set; } = "https://interfacepc.music.163.com/eapi/user/delfollow/";
+
+        public override HttpMethod Method => HttpMethod.Post;
+
+        public override Task MapRequest(ApiHandlerOption option)
+        {
+            ActualRequest = new UserUnfollowActualRequestBase();
+            if (Request is not null)
+            {
+                Url += Request.Id;
+                ApiPath += Request.Id;
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+
+    public class UserUnfollowActualRequestBase : EApiActualRequestBase
+    {
+    }
+
+    public class UserUnfollowResponse : CodedResponseBase
+    {
+    }
+
+    public class UserUnfollowRequest : RequestBase
+    {
+        public required string Id { get; set; }
+    }
+}

--- a/HyPlayer.NeteaseApi/ApiContracts/Utils/BatchApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Utils/BatchApi.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseApi.ApiContracts.Utils;
+﻿using HyPlayer.NeteaseApi.ApiContracts.Utils;
 using HyPlayer.NeteaseApi.Bases;
 using HyPlayer.NeteaseApi.Bases.EApiContractBases;
 using HyPlayer.NeteaseApi.Extensions;

--- a/HyPlayer.NeteaseApi/ApiContracts/Utils/LoginAnnounceDeviceApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Utils/LoginAnnounceDeviceApi.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseApi.ApiContracts.Utils;
+﻿using HyPlayer.NeteaseApi.ApiContracts.Utils;
 using HyPlayer.NeteaseApi.Bases;
 using HyPlayer.NeteaseApi.Bases.EApiContractBases;
 using HyPlayer.NeteaseApi.Extensions;

--- a/HyPlayer.NeteaseApi/ApiContracts/Utils/PasswordUrlDecodeApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Utils/PasswordUrlDecodeApi.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseApi.ApiContracts.Utils;
+﻿using HyPlayer.NeteaseApi.ApiContracts.Utils;
 using HyPlayer.NeteaseApi.Bases;
 using HyPlayer.NeteaseApi.Bases.EApiContractBases;
 using System.Text.Json.Serialization;

--- a/HyPlayer.NeteaseApi/ApiContracts/Utils/RegisterAnonymousApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Utils/RegisterAnonymousApi.cs
@@ -1,5 +1,6 @@
 using HyPlayer.NeteaseApi.ApiContracts.Utils;
 using HyPlayer.NeteaseApi.Bases;
+using HyPlayer.NeteaseApi.Bases.ApiContractBases;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json.Serialization;

--- a/HyPlayer.NeteaseApi/ApiContracts/Utils/RegisterAnonymousApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Utils/RegisterAnonymousApi.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseApi.ApiContracts.Utils;
+﻿using HyPlayer.NeteaseApi.ApiContracts.Utils;
 using HyPlayer.NeteaseApi.Bases;
 using HyPlayer.NeteaseApi.Bases.ApiContractBases;
 using System.Security.Cryptography;

--- a/HyPlayer.NeteaseApi/ApiContracts/Utils/RegisterAnonymousApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Utils/RegisterAnonymousApi.cs
@@ -1,6 +1,5 @@
 using HyPlayer.NeteaseApi.ApiContracts.Utils;
 using HyPlayer.NeteaseApi.Bases;
-using HyPlayer.NeteaseApi.Bases.ApiContractBases;
 using System.Security.Cryptography;
 using System.Text;
 using System.Text.Json.Serialization;

--- a/HyPlayer.NeteaseApi/ApiContracts/Video/VideoSubscribeApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Video/VideoSubscribeApi.cs
@@ -1,0 +1,53 @@
+﻿using HyPlayer.NeteaseApi.ApiContracts.Video;
+using HyPlayer.NeteaseApi.Bases;
+using HyPlayer.NeteaseApi.Bases.EApiContractBases;
+using System.Text.Json.Serialization;
+
+namespace HyPlayer.NeteaseApi.ApiContracts
+{
+    public static partial class NeteaseApis
+    {
+        public static VideoSubscribeApi VideoSubscribeApi => new();
+    }
+}
+
+namespace HyPlayer.NeteaseApi.ApiContracts.Video
+{
+
+    public class VideoSubscribeApi : EApiContractBase<VideoSubscribeRequest, VideoSubscribeResponse, ErrorResultBase,
+        VideoSubscribeActualRequest>
+    {
+        public override string IdentifyRoute => "/mv/subscribe";
+        public override string Url { get; protected set; } = "https://interface.music.163.com/eapi/mv/sub";
+        public override HttpMethod Method => HttpMethod.Post;
+
+        public override Task MapRequest(ApiHandlerOption option)
+        {
+            if (Request is not null)
+            {
+                ActualRequest = new VideoSubscribeActualRequest
+                {
+                    MvId = Request.MvId
+                };
+            }
+
+            return Task.CompletedTask;
+        }
+
+        public override string ApiPath { get; protected set; } = "/api/mv/sub";
+    }
+
+    public class VideoSubscribeRequest : RequestBase
+    {
+        public required string MvId { get; set; }
+    }
+
+    public class VideoSubscribeResponse : CodedResponseBase
+    {
+    }
+
+    public class VideoSubscribeActualRequest : EApiActualRequestBase
+    {
+        [JsonPropertyName("mvId")] public required string MvId { get; set; }
+    }
+}

--- a/HyPlayer.NeteaseApi/ApiContracts/Video/VideoUnsubscribeApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Video/VideoUnsubscribeApi.cs
@@ -17,11 +17,11 @@ namespace HyPlayer.NeteaseApi.ApiContracts.Video
     public class VideoUnsubscribeApi : EApiContractBase<VideoUnsubscribeRequest, VideoUnsubscribeResponse, ErrorResultBase,
         VideoUnsubscribeActualRequest>
     {
-        public override string ApiPath { get; protected set; } = "/api/video/unsub";
+        public override string ApiPath { get; protected set; } = "/api/mv/unsub";
 
-        public override string IdentifyRoute => "/video/unsub";
+        public override string IdentifyRoute => "/mv/unsub";
 
-        public override string Url { get; protected set; } = "https://interface.music.163.com/eapi/video/";
+        public override string Url { get; protected set; } = "https://interface.music.163.com/eapi/mv/unsub";
 
         public override HttpMethod Method => HttpMethod.Post;
 
@@ -31,21 +31,16 @@ namespace HyPlayer.NeteaseApi.ApiContracts.Video
             {
                 ActualRequest = new VideoUnsubscribeActualRequest
                 {
-                    // serialize C# array of ids to JSON array string expected by the API
-                    VideoIds = JsonSerializer.Serialize(Request.VideoIds)
+                    VideoIds = Request.ConvertToQuotedIdStringList()
                 };
-                Url += "unsub";
             }
             return Task.CompletedTask;
         }
     }
 
-    public class VideoUnsubscribeRequest : RequestBase
+    public class VideoUnsubscribeRequest : IdOrIdListListRequest
     {
-        /// <summary>
-        /// Array of artist ids. Will be converted to a JSON array string in the request, e.g. new long[] { 35374786 } -> "[35374786]"
-        /// </summary>
-        public required string[] VideoIds { get; set; }
+        
     }
 
     public class VideoUnsubscribeResponse : CodedResponseBase

--- a/HyPlayer.NeteaseApi/ApiContracts/Video/VideoUnsubscribeApi.cs
+++ b/HyPlayer.NeteaseApi/ApiContracts/Video/VideoUnsubscribeApi.cs
@@ -1,0 +1,59 @@
+﻿using HyPlayer.NeteaseApi.Bases;
+using HyPlayer.NeteaseApi.Bases.EApiContractBases;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using HyPlayer.NeteaseApi.ApiContracts.Video;
+
+namespace HyPlayer.NeteaseApi.ApiContracts
+{
+    public static partial class NeteaseApis
+    {
+        public static VideoUnsubscribeApi VideoUnsubscribeApi => new();
+    }
+}
+
+namespace HyPlayer.NeteaseApi.ApiContracts.Video
+{
+    public class VideoUnsubscribeApi : EApiContractBase<VideoUnsubscribeRequest, VideoUnsubscribeResponse, ErrorResultBase,
+        VideoUnsubscribeActualRequest>
+    {
+        public override string ApiPath { get; protected set; } = "/api/video/unsub";
+
+        public override string IdentifyRoute => "/video/unsub";
+
+        public override string Url { get; protected set; } = "https://interface.music.163.com/eapi/video/";
+
+        public override HttpMethod Method => HttpMethod.Post;
+
+        public override Task MapRequest(ApiHandlerOption option)
+        {
+            if (Request is not null)
+            {
+                ActualRequest = new VideoUnsubscribeActualRequest
+                {
+                    // serialize C# array of ids to JSON array string expected by the API
+                    VideoIds = JsonSerializer.Serialize(Request.VideoIds)
+                };
+                Url += "unsub";
+            }
+            return Task.CompletedTask;
+        }
+    }
+
+    public class VideoUnsubscribeRequest : RequestBase
+    {
+        /// <summary>
+        /// Array of artist ids. Will be converted to a JSON array string in the request, e.g. new long[] { 35374786 } -> "[35374786]"
+        /// </summary>
+        public required string[] VideoIds { get; set; }
+    }
+
+    public class VideoUnsubscribeResponse : CodedResponseBase
+    {
+    }
+
+    public class VideoUnsubscribeActualRequest : EApiActualRequestBase
+    {
+        [JsonPropertyName("mvIds")] public required string VideoIds { get; set; }
+    }
+}

--- a/HyPlayer.NeteaseApi/Bases/ApiContractBases/ActualRequestBase.cs
+++ b/HyPlayer.NeteaseApi/Bases/ApiContractBases/ActualRequestBase.cs
@@ -1,4 +1,4 @@
-namespace HyPlayer.NeteaseApi.Bases.ApiContractBases;
+﻿namespace HyPlayer.NeteaseApi.Bases.ApiContractBases;
 
 public class ActualRequestBase
 {

--- a/HyPlayer.NeteaseApi/Bases/ApiContractBases/ApiContractBase.cs
+++ b/HyPlayer.NeteaseApi/Bases/ApiContractBases/ApiContractBase.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseApi.Bases.ApiContractBases;
+﻿using HyPlayer.NeteaseApi.Bases.ApiContractBases;
 using HyPlayer.NeteaseApi.Extensions;
 
 namespace HyPlayer.NeteaseApi.Bases;

--- a/HyPlayer.NeteaseApi/Bases/ApiContractBases/ErrorResultBase.cs
+++ b/HyPlayer.NeteaseApi/Bases/ApiContractBases/ErrorResultBase.cs
@@ -1,4 +1,4 @@
-namespace HyPlayer.NeteaseApi.Bases;
+﻿namespace HyPlayer.NeteaseApi.Bases;
 
 public class ErrorResultBase : Exception
 {

--- a/HyPlayer.NeteaseApi/Bases/ApiContractBases/ExceptionedErrorBase.cs
+++ b/HyPlayer.NeteaseApi/Bases/ApiContractBases/ExceptionedErrorBase.cs
@@ -1,4 +1,4 @@
-namespace HyPlayer.NeteaseApi.Bases;
+﻿namespace HyPlayer.NeteaseApi.Bases;
 
 public class ExceptionedErrorBase : ErrorResultBase
 {

--- a/HyPlayer.NeteaseApi/Bases/ApiContractBases/IdOrIdListRequest.cs
+++ b/HyPlayer.NeteaseApi/Bases/ApiContractBases/IdOrIdListRequest.cs
@@ -3,12 +3,12 @@
 public class IdOrIdListListRequest : RequestBase
 {
     /// <summary>
-    /// 歌曲 ID 列表
+    /// 资源 ID 列表
     /// </summary>
     public List<string>? IdList { get; set; }
 
     /// <summary>
-    /// 歌曲 ID
+    /// 资源 ID
     /// </summary>
     public string? Id { get; set; }
 

--- a/HyPlayer.NeteaseApi/Bases/ApiContractBases/ResponseBase.cs
+++ b/HyPlayer.NeteaseApi/Bases/ApiContractBases/ResponseBase.cs
@@ -1,4 +1,4 @@
-namespace HyPlayer.NeteaseApi.Bases;
+﻿namespace HyPlayer.NeteaseApi.Bases;
 
 public class ResponseBase
 {

--- a/HyPlayer.NeteaseApi/Bases/EApiContractBases/IBatchableApi.cs
+++ b/HyPlayer.NeteaseApi/Bases/EApiContractBases/IBatchableApi.cs
@@ -1,4 +1,4 @@
-namespace HyPlayer.NeteaseApi.Bases.EApiContractBases;
+﻿namespace HyPlayer.NeteaseApi.Bases.EApiContractBases;
 
 public interface IBatchableApi
 {

--- a/HyPlayer.NeteaseApi/Bases/WeApiContractBases/WeApiContractBase.cs
+++ b/HyPlayer.NeteaseApi/Bases/WeApiContractBases/WeApiContractBase.cs
@@ -1,4 +1,4 @@
-﻿using HyPlayer.NeteaseApi.Bases.EApiContractBases;
+﻿using HyPlayer.NeteaseApi.Bases.ApiContractBases;
 using HyPlayer.NeteaseApi.Extensions;
 using System.Numerics;
 using System.Security.Cryptography;
@@ -6,8 +6,9 @@ using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
 using HyPlayer.NeteaseApi.Bases.WeApiContractBases;
+using HyPlayer.NeteaseApi.Bases.EApiContractBases;
 
-namespace HyPlayer.NeteaseApi.Bases.WeApiContractBases;
+namespace HyPlayer.NeteaseApi.Bases.ApiContractBases;
 
 public abstract class WeApiContractBase<TRequest, TResponse, TError, TActualRequest> :
     ApiContractBase<TRequest, TResponse, TError, TActualRequest>

--- a/HyPlayer.NeteaseApi/Bases/WeApiContractBases/WeApiContractBase.cs
+++ b/HyPlayer.NeteaseApi/Bases/WeApiContractBases/WeApiContractBase.cs
@@ -7,7 +7,7 @@ using System.Text.Json;
 using System.Text.RegularExpressions;
 using HyPlayer.NeteaseApi.Bases.WeApiContractBases;
 
-namespace HyPlayer.NeteaseApi.Bases.ApiContractBases;
+namespace HyPlayer.NeteaseApi.Bases.WeApiContractBases;
 
 public abstract class WeApiContractBase<TRequest, TResponse, TError, TActualRequest> :
     ApiContractBase<TRequest, TResponse, TError, TActualRequest>

--- a/HyPlayer.NeteaseApi/Extensions/JsonSerializer/JsonBooleanConverter.cs
+++ b/HyPlayer.NeteaseApi/Extensions/JsonSerializer/JsonBooleanConverter.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace HyPlayer.NeteaseApi.Extensions.JsonSerializer;

--- a/HyPlayer.NeteaseApi/Extensions/JsonSerializer/JsonObjectStringConverter.cs
+++ b/HyPlayer.NeteaseApi/Extensions/JsonSerializer/JsonObjectStringConverter.cs
@@ -1,4 +1,4 @@
-using System.Text.Json;
+﻿using System.Text.Json;
 using System.Text.Json.Serialization;
 
 namespace HyPlayer.NeteaseApi.Extensions.JsonSerializer;

--- a/HyPlayer.NeteaseApi/Extensions/Roslyn/CompilerFeatureRequired.cs
+++ b/HyPlayer.NeteaseApi/Extensions/Roslyn/CompilerFeatureRequired.cs
@@ -1,4 +1,4 @@
-#pragma warning disable
+﻿#pragma warning disable
 #nullable enable annotations
 
 // Licensed to the .NET Foundation under one or more agreements.

--- a/HyPlayer.NeteaseApi/Extensions/Roslyn/ExternalInit.cs
+++ b/HyPlayer.NeteaseApi/Extensions/Roslyn/ExternalInit.cs
@@ -1,4 +1,4 @@
-#pragma warning disable
+﻿#pragma warning disable
 #nullable enable annotations
 
 // Licensed to the .NET Foundation under one or more agreements.

--- a/HyPlayer.NeteaseApi/Extensions/Roslyn/RequeiredAttribute.cs
+++ b/HyPlayer.NeteaseApi/Extensions/Roslyn/RequeiredAttribute.cs
@@ -1,4 +1,4 @@
-#pragma warning disable
+﻿#pragma warning disable
 #nullable enable annotations
 
 // Licensed to the .NET Foundation under one or more agreements.

--- a/HyPlayer.NeteaseApi/HyPlayer.NeteaseApi.csproj
+++ b/HyPlayer.NeteaseApi/HyPlayer.NeteaseApi.csproj
@@ -4,15 +4,15 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>default</LangVersion>
-        <Version>0.1.0</Version>
+        <Version>0.1.1</Version>
         <Authors>HyPlayer Team</Authors>
         <Description>The NeteaseCloudMusic Api</Description>
         <PackageProjectUrl>https://github.com/HyPlayer/HyPlayer.NeteaseProvider</PackageProjectUrl>
         <PackageLicenseUrl>https://github.com/HyPlayer/HyPlayer.NeteaseProvider/blob/main/LICENCE</PackageLicenseUrl>
         <RepositoryUrl>https://github.com/HyPlayer/HyPlayer.NeteaseProvider</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
-        <AssemblyVersion>0.1.0</AssemblyVersion>
-        <FileVersion>0.1.0</FileVersion>
+        <AssemblyVersion>0.1.1</AssemblyVersion>
+        <FileVersion>0.1.1</FileVersion>
         <TargetFrameworks>netstandard2.0;net9.0</TargetFrameworks>
 		<NoWarn>IL2026;IL3050</NoWarn>
         <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>

--- a/HyPlayer.NeteaseApi/HyPlayer.NeteaseApi.csproj
+++ b/HyPlayer.NeteaseApi/HyPlayer.NeteaseApi.csproj
@@ -11,8 +11,8 @@
         <PackageLicenseUrl>https://github.com/HyPlayer/HyPlayer.NeteaseProvider/blob/main/LICENCE</PackageLicenseUrl>
         <RepositoryUrl>https://github.com/HyPlayer/HyPlayer.NeteaseProvider</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
-        <AssemblyVersion>0.1.0</AssemblyVersion>
-        <FileVersion>0.1.0</FileVersion>
+        <AssemblyVersion>0.1.1</AssemblyVersion>
+        <FileVersion>0.1.1</FileVersion>
         <TargetFrameworks>netstandard2.0;net9.0</TargetFrameworks>
 		<NoWarn>IL2026;IL3050</NoWarn>
         <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>

--- a/HyPlayer.NeteaseApi/HyPlayer.NeteaseApi.csproj
+++ b/HyPlayer.NeteaseApi/HyPlayer.NeteaseApi.csproj
@@ -4,16 +4,14 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>default</LangVersion>
-        <Version>0.1.1</Version>
+        <Version>0.1.2</Version>
         <Authors>HyPlayer Team</Authors>
         <Description>The NeteaseCloudMusic Api</Description>
         <PackageProjectUrl>https://github.com/HyPlayer/HyPlayer.NeteaseProvider</PackageProjectUrl>
         <PackageLicenseUrl>https://github.com/HyPlayer/HyPlayer.NeteaseProvider/blob/main/LICENCE</PackageLicenseUrl>
         <RepositoryUrl>https://github.com/HyPlayer/HyPlayer.NeteaseProvider</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
-        <AssemblyVersion>0.1.1</AssemblyVersion>
-        <FileVersion>0.1.1</FileVersion>
-        <TargetFrameworks>netstandard2.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net10.0</TargetFrameworks>
 		<NoWarn>IL2026;IL3050</NoWarn>
         <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
         <Platforms>AnyCPU;x64</Platforms>

--- a/HyPlayer.NeteaseApi/HyPlayer.NeteaseApi.csproj
+++ b/HyPlayer.NeteaseApi/HyPlayer.NeteaseApi.csproj
@@ -18,7 +18,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="System.Text.Json" Version="10.0.1" />
+        <PackageReference Include="System.Text.Json" Version="10.0.3" />
         <PackageReference Include="T4.Build" Version="0.2.5" PrivateAssets="All" />
     </ItemGroup>
 

--- a/HyPlayer.NeteaseApi/Models/ResponseModels/ArtistSongDto.cs
+++ b/HyPlayer.NeteaseApi/Models/ResponseModels/ArtistSongDto.cs
@@ -1,0 +1,17 @@
+﻿using System.Text.Json.Serialization;
+
+namespace HyPlayer.NeteaseApi.Models.ResponseModels;
+
+public class ArtistSongDto
+{
+    [JsonPropertyName("name")] public string? Name { get; set; }
+    [JsonPropertyName("id")] public string? Id { get; set; }
+    [JsonPropertyName("alias")] public string[]? Alias { get; set; }
+    [JsonPropertyName("duration")] public long Duration { get; set; }
+    [JsonPropertyName("transNames")] public string[]? Translations { get; set; }
+    [JsonPropertyName("mvid")] public string? MvId { get; set; }
+    [JsonPropertyName("no")] public int TrackNumber { get; set; }
+    [JsonPropertyName("album")] public AlbumDto? Album { get; set; }
+    [JsonPropertyName("artists")] public ArtistDto[]? Artists { get; set; }
+    [JsonPropertyName("privilege")] public PrivilegeDto? Privilege { get; set; }
+}

--- a/HyPlayer.NeteaseApi/NeteaseCloudMusicApiHandler.cs
+++ b/HyPlayer.NeteaseApi/NeteaseCloudMusicApiHandler.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseApi.Bases;
+﻿using HyPlayer.NeteaseApi.Bases;
 using HyPlayer.NeteaseApi.Bases.ApiContractBases;
 using HyPlayer.NeteaseApi.Extensions;
 using System.Net;

--- a/HyPlayer.NeteaseProvider.Tests/HyPlayer.NeteaseProvider.Tests.csproj
+++ b/HyPlayer.NeteaseProvider.Tests/HyPlayer.NeteaseProvider.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>

--- a/HyPlayer.NeteaseProvider.Tests/NeteaseApisTests.cs
+++ b/HyPlayer.NeteaseProvider.Tests/NeteaseApisTests.cs
@@ -135,8 +135,7 @@ public class NeteaseApisTests
     {
         var result = await _provider.RequestAsync(NeteaseApis.ArtistSongsApi, new ArtistSongsRequest
         {
-            ArtistId = id,
-            OrderType = orderType
+            ArtistId = id
         });
         result.Match(s =>
             {

--- a/HyPlayer.NeteaseProvider.Tests/NeteaseApisTests.cs
+++ b/HyPlayer.NeteaseProvider.Tests/NeteaseApisTests.cs
@@ -1,4 +1,4 @@
-#region
+﻿#region
 
 using AwesomeAssertions;
 using HyPlayer.NeteaseApi.ApiContracts;

--- a/HyPlayer.NeteaseProvider.Tests/NeteaseApisTests.cs
+++ b/HyPlayer.NeteaseProvider.Tests/NeteaseApisTests.cs
@@ -930,7 +930,7 @@ public class NeteaseApisTests
         },
             e => throw e);
     }
-    [Test]
+    /*[Test]
     [Arguments("8645419738")]
     public async Task UserFollow_Should_BeNormal(string id)
     {
@@ -959,5 +959,5 @@ public class NeteaseApisTests
             return true;
         },
             e => throw e);
-    }
+    }*/
 }

--- a/HyPlayer.NeteaseProvider.Tests/NeteaseApisTests.cs
+++ b/HyPlayer.NeteaseProvider.Tests/NeteaseApisTests.cs
@@ -867,4 +867,97 @@ public class NeteaseApisTests
             },
             e => throw e);
     }
+    [Test]
+    [Arguments("14548918")]
+    public async Task VideoSubscribe_Should_BeNormal(string id)
+    {
+        var result = await _provider.RequestAsync(NeteaseApis.VideoSubscribeApi, new VideoSubscribeRequest
+        {
+            MvId = id
+        });
+        result.Match(s =>
+        {
+            s.Code.Should().Be(200);
+            return true;
+        },
+            e => throw e);
+    }
+    [Test]
+    [Arguments("14548918")]
+    public async Task VideoUnsubscribe_Should_BeNormal(string id)
+    {
+        var result = await _provider.RequestAsync(NeteaseApis.VideoUnsubscribeApi, new VideoUnsubscribeRequest
+        {
+            Id = id
+        });
+        result.Match(s =>
+        {
+            s.Code.Should().Be(200);
+            return true;
+        },
+            e => throw e);
+    }
+
+    [Test]
+    [Arguments("793914432")]
+    public async Task DJChannelSubscribe_Should_BeNormal(string id)
+    {
+        var result = await _provider.RequestAsync(NeteaseApis.DjChannelSubscribeApi, new DjChannelSubscribeRequest
+        {
+            Id = id,
+            IsSubscribe = true
+        });
+        result.Match(s =>
+        {
+            s.Code.Should().Be(200);
+            return true;
+        },
+            e => throw e);
+    }
+    [Test]
+    [Arguments("793914432")]
+    public async Task DJChannelUnsubscribe_Should_BeNormal(string id)
+    {
+        var result = await _provider.RequestAsync(NeteaseApis.DjChannelSubscribeApi, new DjChannelSubscribeRequest
+        {
+            Id = id,
+            IsSubscribe = false
+        });
+        result.Match(s =>
+        {
+            s.Code.Should().Be(200);
+            return true;
+        },
+            e => throw e);
+    }
+    [Test]
+    [Arguments("8645419738")]
+    public async Task UserFollow_Should_BeNormal(string id)
+    {
+        var result = await _provider.RequestAsync(NeteaseApis.UserFollowApi, new UserFollowRequest
+        {
+            Id = id
+        });
+        result.Match(s =>
+        {
+            s.Code.Should().Be(200);
+            return true;
+        },
+            e => throw e);
+    }
+    [Test]
+    [Arguments("8645419738")]
+    public async Task UserUnfollow_Should_BeNormal(string id)
+    {
+        var result = await _provider.RequestAsync(NeteaseApis.UserUnfollowApi, new UserUnfollowRequest
+        {
+            Id = id
+        });
+        result.Match(s =>
+        {
+            s.Code.Should().Be(200);
+            return true;
+        },
+            e => throw e);
+    }
 }

--- a/HyPlayer.NeteaseProvider.slnx
+++ b/HyPlayer.NeteaseProvider.slnx
@@ -4,6 +4,7 @@
     <File Path="global.json" />
     <File Path="HyPlayer.NeteaseProvider.sln.DotSettings" />
     <File Path="LICENCE" />
+    <File Path="README.md" />
     <File Path="renovate.json" />
   </Folder>
   <Folder Name="/Solution Items/workflows/">

--- a/HyPlayer.NeteaseProvider/Extensions/Roslyn/CompilerFeatureRequired.cs
+++ b/HyPlayer.NeteaseProvider/Extensions/Roslyn/CompilerFeatureRequired.cs
@@ -1,4 +1,4 @@
-#pragma warning disable
+﻿#pragma warning disable
 #nullable enable annotations
 
 // Licensed to the .NET Foundation under one or more agreements.

--- a/HyPlayer.NeteaseProvider/Extensions/Roslyn/ExternalInit.cs
+++ b/HyPlayer.NeteaseProvider/Extensions/Roslyn/ExternalInit.cs
@@ -1,4 +1,4 @@
-#pragma warning disable
+﻿#pragma warning disable
 #nullable enable annotations
 
 // Licensed to the .NET Foundation under one or more agreements.

--- a/HyPlayer.NeteaseProvider/Extensions/Roslyn/RequeiredAttribute.cs
+++ b/HyPlayer.NeteaseProvider/Extensions/Roslyn/RequeiredAttribute.cs
@@ -1,4 +1,4 @@
-#pragma warning disable
+﻿#pragma warning disable
 #nullable enable annotations
 
 // Licensed to the .NET Foundation under one or more agreements.

--- a/HyPlayer.NeteaseProvider/HyPlayer.NeteaseProvider.csproj
+++ b/HyPlayer.NeteaseProvider/HyPlayer.NeteaseProvider.csproj
@@ -4,7 +4,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
-        <Version>0.0.11</Version>
+        <Version>0.1.0</Version>
         <Title>HyPlayer.NeteaseProvider</Title>
         <Authors>HyPlayer Team</Authors>
         <Description>The NeteaseProvider for HyPlayer</Description>
@@ -12,8 +12,8 @@
         <PackageLicenseUrl>https://github.com/HyPlayer/HyPlayer.NeteaseProvider/blob/main/LICENCE</PackageLicenseUrl>
         <RepositoryUrl>https://github.com/HyPlayer/HyPlayer.NeteaseProvider</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
-        <AssemblyVersion>0.0.11</AssemblyVersion>
-        <FileVersion>0.0.11</FileVersion>
+        <AssemblyVersion>0.1.0</AssemblyVersion>
+        <FileVersion>0.1.0</FileVersion>
         <TargetFrameworks>netstandard2.0;net9.0</TargetFrameworks>
         <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
     </PropertyGroup>

--- a/HyPlayer.NeteaseProvider/HyPlayer.NeteaseProvider.csproj
+++ b/HyPlayer.NeteaseProvider/HyPlayer.NeteaseProvider.csproj
@@ -14,7 +14,7 @@
         <RepositoryType>git</RepositoryType>
         <AssemblyVersion>0.0.12</AssemblyVersion>
         <FileVersion>0.0.12</FileVersion>
-        <TargetFrameworks>netstandard2.0;net9.0</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;net10.0</TargetFrameworks>
         <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
     </PropertyGroup>
 

--- a/HyPlayer.NeteaseProvider/HyPlayer.NeteaseProvider.csproj
+++ b/HyPlayer.NeteaseProvider/HyPlayer.NeteaseProvider.csproj
@@ -4,11 +4,7 @@
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
-<<<<<<< HEAD
-        <Version>0.1.0</Version>
-=======
         <Version>0.0.12</Version>
->>>>>>> a116ed35614328753f05586a6294022afce6b52a
         <Title>HyPlayer.NeteaseProvider</Title>
         <Authors>HyPlayer Team</Authors>
         <Description>The NeteaseProvider for HyPlayer</Description>
@@ -16,13 +12,8 @@
         <PackageLicenseUrl>https://github.com/HyPlayer/HyPlayer.NeteaseProvider/blob/main/LICENCE</PackageLicenseUrl>
         <RepositoryUrl>https://github.com/HyPlayer/HyPlayer.NeteaseProvider</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
-<<<<<<< HEAD
-        <AssemblyVersion>0.1.0</AssemblyVersion>
-        <FileVersion>0.1.0</FileVersion>
-=======
         <AssemblyVersion>0.0.12</AssemblyVersion>
         <FileVersion>0.0.12</FileVersion>
->>>>>>> a116ed35614328753f05586a6294022afce6b52a
         <TargetFrameworks>netstandard2.0;net9.0</TargetFrameworks>
         <IsAotCompatible Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">true</IsAotCompatible>
     </PropertyGroup>

--- a/HyPlayer.NeteaseProvider/Mappers/DjRadioProgramToNeteaseRadioProgramMapper.cs
+++ b/HyPlayer.NeteaseProvider/Mappers/DjRadioProgramToNeteaseRadioProgramMapper.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseApi.Models.ResponseModels;
+锘縰sing HyPlayer.NeteaseApi.Models.ResponseModels;
 using HyPlayer.NeteaseProvider.Models;
 
 namespace HyPlayer.NeteaseProvider.Mappers;
@@ -10,7 +10,7 @@ public static class DjRadioProgramToNeteaseRadioProgramMapper
         return new NeteaseRadioProgram
         {
             ActualId = program.Id!,
-            Name = program.Name ?? "未知节目",
+            Name = program.Name ?? "鏈煡鑺傜洰",
             PictureUrl = program.PictureUrl,
             CoverUrl = program.CoverUrl,
             Description = program.Description,
@@ -27,7 +27,7 @@ public static class DjRadioProgramToNeteaseRadioProgramMapper
             SerialNum = program.SerialNum,
             Host = program.Owner?.MapToNeteaseUser(),
             CreatorList = program.Owner != null
-                ? new List<string> { program.Owner.Nickname ?? program.Owner.UserId ?? "未知主播" }
+                ? new List<string> { program.Owner.Nickname ?? program.Owner.UserId ?? "鏈煡涓绘挱" }
                 : new List<string>(),
             Duration = program.MainSong?.Duration ?? program.Duration,
             Available = true

--- a/HyPlayer.NeteaseProvider/Mappers/DjRadioProgramToNeteaseRadioProgramMapper.cs
+++ b/HyPlayer.NeteaseProvider/Mappers/DjRadioProgramToNeteaseRadioProgramMapper.cs
@@ -1,0 +1,36 @@
+using HyPlayer.NeteaseApi.Models.ResponseModels;
+using HyPlayer.NeteaseProvider.Models;
+
+namespace HyPlayer.NeteaseProvider.Mappers;
+
+public static class DjRadioProgramToNeteaseRadioProgramMapper
+{
+    public static NeteaseRadioProgram MapToNeteaseRadioProgram(this DjRadioProgramDto program)
+    {
+        return new NeteaseRadioProgram
+        {
+            ActualId = program.Id!,
+            Name = program.Name ?? "未知节目",
+            PictureUrl = program.PictureUrl,
+            CoverUrl = program.CoverUrl,
+            Description = program.Description,
+            ProgramDuration = program.Duration,
+            RadioChannel = program.Radio?.MapToNeteaseRadioChannel(),
+            MainSong = program.MainSong?.MapToNeteaseMusic(),
+            Bought = program.Bought,
+            ListenerCount = program.ListenerCount,
+            SubscribedCount = program.SubscribedCount,
+            CommentCount = program.CommentCount,
+            ShareCount = program.ShareCount,
+            LikedCount = program.LikedCount,
+            CreateTime = program.CreateTime,
+            SerialNum = program.SerialNum,
+            Host = program.Owner?.MapToNeteaseUser(),
+            CreatorList = program.Owner != null
+                ? new List<string> { program.Owner.Nickname ?? program.Owner.UserId ?? "未知主播" }
+                : new List<string>(),
+            Duration = program.MainSong?.Duration ?? program.Duration,
+            Available = true
+        };
+    }
+}

--- a/HyPlayer.NeteaseProvider/Mappers/PlaylistItemToNeteasePlaylistMapper.cs
+++ b/HyPlayer.NeteaseProvider/Mappers/PlaylistItemToNeteasePlaylistMapper.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseApi.ApiContracts;
+﻿using HyPlayer.NeteaseApi.ApiContracts;
 using HyPlayer.NeteaseApi.ApiContracts.Playlist;
 using HyPlayer.NeteaseApi.Models.ResponseModels;
 using HyPlayer.NeteaseProvider.Models;

--- a/HyPlayer.NeteaseProvider/Mappers/RadioChannelToNeteaseRadioChannelMapper.cs
+++ b/HyPlayer.NeteaseProvider/Mappers/RadioChannelToNeteaseRadioChannelMapper.cs
@@ -5,14 +5,55 @@ namespace HyPlayer.NeteaseProvider.Mappers;
 
 public static class RadioChannelToNeteaseRadioChannelMapper
 {
+    /// <summary>
+    /// 将 DjRadioChannelDto 映射到 NeteaseRadioChannel
+    /// </summary>
     public static NeteaseRadioChannel MapToNeteaseRadioChannel(this DjRadioChannelDto radioChannel)
     {
-        // TODO: Implement mapping
         return new NeteaseRadioChannel
         {
-            ActualId = radioChannel.Id,
-            Name = radioChannel.Name ?? "",
+            ActualId = radioChannel.Id!,
+            Name = radioChannel.Name ?? "未知电台",
             Description = radioChannel.Description,
+            ProgramCount = radioChannel.ProgramCount,
+            CreateTime = radioChannel.CreateTime,
+            SubscribedCount = radioChannel.SubscribedCount,
+            CoverUrl = radioChannel.CoverUrl,
+            CategoryId = radioChannel.CategoryId,
+            Category = radioChannel.Category,
+            SecondCategoryId = radioChannel.SecondCategoryId,
+            SecondCategory = radioChannel.SecondCategory,
+            LikedCount = radioChannel.LikedCount,
+            CommentCount = radioChannel.CommentCount,
+            ShareCount = radioChannel.ShareCount,
+            PlayCount = radioChannel.PlayCount,
+            RecommendText = radioChannel.RecommendText,
+            Price = radioChannel.Price,
+            Bought = radioChannel.Bought,
+            LastProgramCreateTime = radioChannel.LastProgramCreateTime,
+            LastProgramId = radioChannel.LastProgramId,
+            LastProgramName = radioChannel.LastProgramName,
+            IsHighQuality = radioChannel.IsHighQuality,
+            Subscribed = radioChannel.Subscribed,
+            CreatorList = new List<string>()
         };
+    }
+
+    /// <summary>
+    /// 将 DjRadioChannelWithDjDto 映射到 NeteaseRadioChannel
+    /// </summary>
+    public static NeteaseRadioChannel MapToNeteaseRadioChannel(this DjRadioChannelWithDjDto radioChannel)
+    {
+        var channel = ((DjRadioChannelDto)radioChannel).MapToNeteaseRadioChannel();
+        
+        if (radioChannel.DjData != null)
+        {
+            var host = radioChannel.DjData.MapToNeteaseUser();
+            channel.Host = host;
+            channel.CreatorList?.Clear();
+            channel.CreatorList?.Add(host.Name);
+        }
+
+        return channel;
     }
 }

--- a/HyPlayer.NeteaseProvider/Mappers/SongDetailItemToNeteaseMusicMapper.cs
+++ b/HyPlayer.NeteaseProvider/Mappers/SongDetailItemToNeteaseMusicMapper.cs
@@ -73,4 +73,20 @@ public static class SongDetailItemToNeteaseMusicMapper
             CoverUrl = item.Album?.PictureUrl
         };
     }
+    public static NeteaseSong MapToNeteaseMusic(this ArtistSongDto item)
+    {
+        return new NeteaseSong
+        {
+            Name = item.Name ?? "未知歌曲",
+            ActualId = item.Id!,
+            Album = item.Album.MapToNeteaseAlbum(),
+            CreatorList = item.Artists is { Length: > 0 }
+                       ? item.Artists.Select(ar => ar.Name ?? "未知歌手").ToList()
+                       : new List<string>(),
+            Duration = item.Duration,
+            Available = item.Privilege?.PlayLevel is not (null or "none"),
+            Artists = item.Artists?.Select(ar => (PersonBase)ar.MapToNeteaseArtist()).ToList(),
+            CoverUrl = item.Album?.PictureUrl
+        };
+    }
 }

--- a/HyPlayer.NeteaseProvider/Models/NeteaseActionGettableContainer.cs
+++ b/HyPlayer.NeteaseProvider/Models/NeteaseActionGettableContainer.cs
@@ -21,7 +21,7 @@ public class NeteaseActionGettableContainer : LinerContainerBase
 
     public Func<Task<List<ProvidableItemBase>>>? Getter { get; set; }
 
-    public override async Task<List<ProvidableItemBase>> GetAllItemsAsync(CancellationToken ctk = new())
+    public override async Task<List<ProvidableItemBase>> GetAllItemsAsync(CancellationToken ctk = default)
     {
         return await (Getter?.Invoke() ?? Task.FromResult(new List<ProvidableItemBase>()));
     }
@@ -38,13 +38,13 @@ public class NeteaseActionGettableProgressiveContainer : NeteaseActionGettableCo
     public Func<int, int, Task<(bool, List<ProvidableItemBase>)>>? ProgressiveGetter { get; set; }
 
 
-    public async Task<(bool, List<ProvidableItemBase>)> GetProgressiveItemsListAsync(int start, int count, CancellationToken ctk = new())
+    public async Task<(bool, List<ProvidableItemBase>)> GetProgressiveItemsListAsync(int start, int count, CancellationToken ctk = default))
     {
         return await (ProgressiveGetter?.Invoke(start, count) ??
                       Task.FromResult((false, new List<ProvidableItemBase>())));
     }
 
-    public override async Task<List<ProvidableItemBase>> GetAllItemsAsync(CancellationToken ctk = new())
+    public override async Task<List<ProvidableItemBase>> GetAllItemsAsync(CancellationToken ctk = default)
     {
         return (await GetProgressiveItemsListAsync(0, MaxProgressiveCount, ctk)).Item2;
     }
@@ -64,7 +64,7 @@ public class NeteaseActionGettableUndetermindContainer : UndeterminedContainerBa
     public Func<Task<List<ProvidableItemBase>>>? ProgressiveGetter { get; set; }
 
 
-    public override async Task<List<ProvidableItemBase>> GetNextItemsRangeAsync(CancellationToken ctk = new CancellationToken())
+    public override async Task<List<ProvidableItemBase>> GetNextItemsRangeAsync(CancellationToken ctk = default)
     {
         return await (ProgressiveGetter?.Invoke() ??
                       Task.FromResult(new List<ProvidableItemBase>()));

--- a/HyPlayer.NeteaseProvider/Models/NeteaseActionGettableContainer.cs
+++ b/HyPlayer.NeteaseProvider/Models/NeteaseActionGettableContainer.cs
@@ -38,7 +38,7 @@ public class NeteaseActionGettableProgressiveContainer : NeteaseActionGettableCo
     public Func<int, int, Task<(bool, List<ProvidableItemBase>)>>? ProgressiveGetter { get; set; }
 
 
-    public async Task<(bool, List<ProvidableItemBase>)> GetProgressiveItemsListAsync(int start, int count, CancellationToken ctk = default))
+    public async Task<(bool, List<ProvidableItemBase>)> GetProgressiveItemsListAsync(int start, int count, CancellationToken ctk = default)
     {
         return await (ProgressiveGetter?.Invoke(start, count) ??
                       Task.FromResult((false, new List<ProvidableItemBase>())));

--- a/HyPlayer.NeteaseProvider/Models/NeteaseAlbum.cs
+++ b/HyPlayer.NeteaseProvider/Models/NeteaseAlbum.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseProvider.Constants;
+﻿using HyPlayer.NeteaseProvider.Constants;
 using HyPlayer.PlayCore.Abstraction.Interfaces.ProvidableItem;
 using HyPlayer.PlayCore.Abstraction.Models;
 using HyPlayer.PlayCore.Abstraction.Models.Containers;

--- a/HyPlayer.NeteaseProvider/Models/NeteaseAlbum.cs
+++ b/HyPlayer.NeteaseProvider/Models/NeteaseAlbum.cs
@@ -48,7 +48,7 @@ public class NeteaseAlbum : AlbumBase, IHasCover, IHasTranslation, IHasDescripti
 
     public string? Translation { get; set; }
     public string? Description { get; set; }
-    public Task<List<PersonBase>?> GetCreatorsAsync(CancellationToken ctk = new())
+    public Task<List<PersonBase>?> GetCreatorsAsync(CancellationToken ctk = default)
     {
         if (Artists is null) return Task.FromResult<List<PersonBase>?>(null);
         return Task.FromResult(Artists?.Select(ar => (PersonBase)ar).ToList());

--- a/HyPlayer.NeteaseProvider/Models/NeteaseArtist.cs
+++ b/HyPlayer.NeteaseProvider/Models/NeteaseArtist.cs
@@ -9,7 +9,7 @@ public class NeteaseArtist : ArtistBase
     public override string ProviderId => "ncm";
     public override string TypeId => NeteaseTypeIds.Artist;
 
-    public override Task<List<ContainerBase>> GetSubContainerAsync(CancellationToken ctk = new())
+    public override Task<List<ContainerBase>> GetSubContainerAsync(CancellationToken ctk = default)
     {
         return
             Task.FromResult(new List<ContainerBase>()

--- a/HyPlayer.NeteaseProvider/Models/NeteaseArtist.cs
+++ b/HyPlayer.NeteaseProvider/Models/NeteaseArtist.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseProvider.Constants;
+﻿using HyPlayer.NeteaseProvider.Constants;
 using HyPlayer.PlayCore.Abstraction.Models;
 using HyPlayer.PlayCore.Abstraction.Models.Containers;
 

--- a/HyPlayer.NeteaseProvider/Models/NeteaseArtistSubContainer.cs
+++ b/HyPlayer.NeteaseProvider/Models/NeteaseArtistSubContainer.cs
@@ -13,7 +13,7 @@ public class NeteaseArtistSubContainer : LinerContainerBase, IProgressiveLoading
     public override string ProviderId => "ncm";
     public override string TypeId => NeteaseTypeIds.Artist;
 
-    public override async Task<List<ProvidableItemBase>> GetAllItemsAsync(CancellationToken ctk = new())
+    public override async Task<List<ProvidableItemBase>> GetAllItemsAsync(CancellationToken ctk = default)
     {
         if (ActualId != null)
         {
@@ -72,7 +72,7 @@ public class NeteaseArtistSubContainer : LinerContainerBase, IProgressiveLoading
         else throw new ArgumentNullException();
     }
 
-    public async Task<(bool, List<ProvidableItemBase>)> GetProgressiveItemsListAsync(int start = 0, int count = 50, CancellationToken ctk = new())
+    public async Task<(bool, List<ProvidableItemBase>)> GetProgressiveItemsListAsync(int start = 0, int count = 50, CancellationToken ctk = default)
     {
         if(ActualId!= null) {
         var itemType = ActualId.Substring(0, 3);

--- a/HyPlayer.NeteaseProvider/Models/NeteaseArtistSubContainer.cs
+++ b/HyPlayer.NeteaseProvider/Models/NeteaseArtistSubContainer.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseApi.ApiContracts;
+﻿using HyPlayer.NeteaseApi.ApiContracts;
 using HyPlayer.NeteaseApi.ApiContracts.Artist;
 using HyPlayer.NeteaseProvider.Constants;
 using HyPlayer.NeteaseProvider.Mappers;

--- a/HyPlayer.NeteaseProvider/Models/NeteaseArtistSubContainer.cs
+++ b/HyPlayer.NeteaseProvider/Models/NeteaseArtistSubContainer.cs
@@ -1,5 +1,6 @@
 ﻿using HyPlayer.NeteaseApi.ApiContracts;
 using HyPlayer.NeteaseApi.ApiContracts.Artist;
+using HyPlayer.NeteaseApi.Extensions;
 using HyPlayer.NeteaseProvider.Constants;
 using HyPlayer.NeteaseProvider.Mappers;
 using HyPlayer.PlayCore.Abstraction.Interfaces.PlayListContainer;
@@ -19,55 +20,19 @@ public class NeteaseArtistSubContainer : LinerContainerBase, IProgressiveLoading
         {
             var itemType = ActualId.Substring(0, 3);
             var artistId = ActualId.Substring(3);
-            switch (itemType)
-            {
-                case "hot":
-                default:
-                    var result = await NeteaseProvider.Instance.RequestAsync(
+            var resTime = await NeteaseProvider.Instance.RequestAsync(
                         NeteaseApis.ArtistSongsApi,
                         new ArtistSongsRequest
                         {
                             ArtistId = artistId,
-                            OrderType = ArtistSongsOrderType.Hot,
                             Offset = 0,
                             Limit = 50
                         });
-                    return result.Match(
-                        success =>
-                            success.Songs?.Select(song => (ProvidableItemBase)song.MapToNeteaseMusic()).ToList() ?? [],
-                        error => new List<ProvidableItemBase>()
-                    );
-                case "tim":
-                    var resTime = await NeteaseProvider.Instance.RequestAsync(
-                        NeteaseApis.ArtistSongsApi,
-                        new ArtistSongsRequest
-                        {
-                            ArtistId = artistId,
-                            OrderType = ArtistSongsOrderType.Time,
-                            Offset = 0,
-                            Limit = 50
-                        });
-                    return resTime.Match(
-                        success =>
-                            success.Songs?.Select(song => (ProvidableItemBase)song.MapToNeteaseMusic()).ToList() ?? [],
-                        error => new List<ProvidableItemBase>()
-                    );
-                case "alb":
-                    var resAlbum =
-                        await NeteaseProvider.Instance.RequestAsync(
-                            NeteaseApis.ArtistAlbumsApi,
-                            new ArtistAlbumsRequest()
-                            {
-                                ArtistId = artistId,
-                                Limit = 50,
-                                Start = 0
-                            });
-                    return resAlbum.Match(
-                        success =>
-                            success.Albums?.Select(alb => (ProvidableItemBase)alb.MapToNeteaseAlbum()!).ToList() ?? new(),
-                        error => new List<ProvidableItemBase>()
-                    );
-            }
+            return resTime.Match(
+                success =>
+                    success.Songs?.Select(song => (ProvidableItemBase)song.MapToNeteaseMusic()).ToList() ?? [],
+                error => new List<ProvidableItemBase>()
+            );
         }
         else throw new ArgumentNullException();
     }
@@ -77,41 +42,18 @@ public class NeteaseArtistSubContainer : LinerContainerBase, IProgressiveLoading
         if(ActualId!= null) {
         var itemType = ActualId.Substring(0, 3);
         var artistId = ActualId.Substring(3);
-        switch (itemType)
-        {
-            case "hot":
-            default:
-                var result = await NeteaseProvider.Instance.RequestAsync(
-                    NeteaseApis.ArtistSongsApi,
-                    new ArtistSongsRequest
-                    {
-                        ArtistId = artistId,
-                        OrderType = ArtistSongsOrderType.Hot,
-                        Offset = start,
-                        Limit = count
-                    });
-                return result.Match(
+            var resTime = await NeteaseProvider.Instance.RequestAsync(
+                        NeteaseApis.ArtistSongsApi,
+                        new ArtistSongsRequest
+                        {
+                            ArtistId = artistId,
+                            Offset = 0,
+                            Limit = 50
+                        });
+            return resTime.Match(
                     success => (success.HasMore,
                         success.Songs?.Select(song => (ProvidableItemBase)song.MapToNeteaseMusic()).ToList() ?? new List<ProvidableItemBase>()),
-                    error => (false, new List<ProvidableItemBase>())
-                );
-            case "tim":
-                var resTime = await NeteaseProvider.Instance.RequestAsync(
-                    NeteaseApis.ArtistSongsApi,
-                    new ArtistSongsRequest
-                    {
-                        ArtistId = artistId,
-                        OrderType = ArtistSongsOrderType.Hot,
-                        Offset = 0,
-                        Limit = 50
-                    });
-                return resTime.Match(
-                    success => (success.HasMore,
-                                    success.Songs?.Select(song => (ProvidableItemBase)song.MapToNeteaseMusic()).ToList() ?? new List<ProvidableItemBase>()),
-                                error => (false, new List<ProvidableItemBase>())
-                );
-
-            }
+                    error => (false, new List<ProvidableItemBase>()));
         }
         else throw new ArgumentNullException();
     }

--- a/HyPlayer.NeteaseProvider/Models/NeteaseImageResource.cs
+++ b/HyPlayer.NeteaseProvider/Models/NeteaseImageResource.cs
@@ -1,4 +1,4 @@
-using HyPlayer.PlayCore.Abstraction.Models;
+﻿using HyPlayer.PlayCore.Abstraction.Models;
 using HyPlayer.PlayCore.Abstraction.Models.Resources;
 
 namespace HyPlayer.NeteaseProvider.Models;

--- a/HyPlayer.NeteaseProvider/Models/NeteaseImageResourceQualityTag.cs
+++ b/HyPlayer.NeteaseProvider/Models/NeteaseImageResourceQualityTag.cs
@@ -1,4 +1,4 @@
-using HyPlayer.PlayCore.Abstraction.Models.Resources;
+﻿using HyPlayer.PlayCore.Abstraction.Models.Resources;
 
 namespace HyPlayer.NeteaseProvider.Models
 {

--- a/HyPlayer.NeteaseProvider/Models/NeteaseMusicResource.cs
+++ b/HyPlayer.NeteaseProvider/Models/NeteaseMusicResource.cs
@@ -1,4 +1,4 @@
-using HyPlayer.PlayCore.Abstraction.Models;
+﻿using HyPlayer.PlayCore.Abstraction.Models;
 using HyPlayer.PlayCore.Abstraction.Models.Resources;
 
 namespace HyPlayer.NeteaseProvider.Models;

--- a/HyPlayer.NeteaseProvider/Models/NeteaseMv.cs
+++ b/HyPlayer.NeteaseProvider/Models/NeteaseMv.cs
@@ -10,7 +10,7 @@ public class NeteaseMv : ProvidableItemBase, IHasCover
     public override string ProviderId => "ncm";
     public override string TypeId => NeteaseTypeIds.Mv;
     public string? CoverUrl { get; set; }
-    public async Task<ResourceResultBase> GetCoverAsync(ImageResourceQualityTag? qualityTag = null, CancellationToken ctk = new CancellationToken())
+    public async Task<ResourceResultBase> GetCoverAsync(ImageResourceQualityTag? qualityTag = null, CancellationToken ctk = default)
     {
         if (qualityTag is NeteaseImageResourceQualityTag neteaseImageResourceQualityTag)
         {

--- a/HyPlayer.NeteaseProvider/Models/NeteasePersonalFMContainer.cs
+++ b/HyPlayer.NeteaseProvider/Models/NeteasePersonalFMContainer.cs
@@ -14,7 +14,7 @@ public class NeteasePersonalFMContainer : UndeterminedContainerBase
 
     public string RecommendType = "DEFAULT";
 
-    public override async Task<List<ProvidableItemBase>> GetNextItemsRangeAsync(CancellationToken ctk = new CancellationToken())
+    public override async Task<List<ProvidableItemBase>> GetNextItemsRangeAsync(CancellationToken ctk = default)
     {
         return (await NeteaseProvider.Instance.RequestAsync(NeteaseApis.PersonalFmApi, new PersonalFmRequest() { Mode = RecommendType }, ctk))
             .Match(s => s.Items?.Select(t => (ProvidableItemBase)t.MapToNeteaseMusic()).ToList() ?? new List<ProvidableItemBase>(),

--- a/HyPlayer.NeteaseProvider/Models/NeteasePlaylist.cs
+++ b/HyPlayer.NeteaseProvider/Models/NeteasePlaylist.cs
@@ -28,7 +28,7 @@ public class NeteasePlaylist : LinerContainerBase, IProgressiveLoadingContainer,
     public long ShareCount { get; set; }
     public bool IsNewImported { get; set; }
 
-    public async Task UpdatePlaylistInfoAsync(CancellationToken ctk = new())
+    public async Task UpdatePlaylistInfoAsync(CancellationToken ctk = default)
     {
         var results = await NeteaseProvider.Instance.RequestAsync(
             NeteaseApis.PlaylistDetailApi,
@@ -59,7 +59,7 @@ public class NeteasePlaylist : LinerContainerBase, IProgressiveLoadingContainer,
             }, error => false);
     }
 
-    public async Task UpdateTrackListAsync(CancellationToken ctk = new())
+    public async Task UpdateTrackListAsync(CancellationToken ctk = default)
     {
         if (ActualId == null) throw new ArgumentNullException();
         _trackIds = (await NeteaseProvider.Instance.RequestAsync(NeteaseApis.PlaylistTracksGetApi,
@@ -71,7 +71,7 @@ public class NeteasePlaylist : LinerContainerBase, IProgressiveLoadingContainer,
             error => { return Array.Empty<PlaylistTracksGetResponse.PlaylistWithTracksInfoDto.TrackIdItem>(); });
     }
 
-    public override async Task<List<ProvidableItemBase>> GetAllItemsAsync(CancellationToken ctk = new())
+    public override async Task<List<ProvidableItemBase>> GetAllItemsAsync(CancellationToken ctk = default)
     {
         if (_trackIds is null)
             await UpdateTrackListAsync(ctk);
@@ -82,7 +82,7 @@ public class NeteasePlaylist : LinerContainerBase, IProgressiveLoadingContainer,
     }
 
     public async Task<(bool, List<ProvidableItemBase>)> GetProgressiveItemsListAsync(
-        int start, int count, CancellationToken ctk = new())
+        int start, int count, CancellationToken ctk = default)
     {
         if (_trackIds is null)
             await UpdatePlaylistInfoAsync(ctk);
@@ -98,7 +98,7 @@ public class NeteasePlaylist : LinerContainerBase, IProgressiveLoadingContainer,
 
     public string? Description { get; set; }
 
-    public Task<List<PersonBase>?> GetCreatorsAsync(CancellationToken ctk = new())
+    public Task<List<PersonBase>?> GetCreatorsAsync(CancellationToken ctk = default)
     {
         return Task.FromResult(new List<PersonBase> { Creator! })!;
     }

--- a/HyPlayer.NeteaseProvider/Models/NeteasePlaylist.cs
+++ b/HyPlayer.NeteaseProvider/Models/NeteasePlaylist.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseApi.ApiContracts;
+﻿using HyPlayer.NeteaseApi.ApiContracts;
 using HyPlayer.NeteaseApi.ApiContracts.Playlist;
 using HyPlayer.NeteaseProvider.Constants;
 using HyPlayer.NeteaseProvider.Mappers;

--- a/HyPlayer.NeteaseProvider/Models/NeteaseRadioChannel.cs
+++ b/HyPlayer.NeteaseProvider/Models/NeteaseRadioChannel.cs
@@ -124,7 +124,7 @@ IHasCreators
     /// <summary>
     /// 获取所有节目
     /// </summary>
-    public override async Task<List<ProvidableItemBase>> GetAllItemsAsync(CancellationToken ctk = new CancellationToken())
+    public override async Task<List<ProvidableItemBase>> GetAllItemsAsync(CancellationToken ctk = default)
     {
         var programs = new List<NeteaseRadioProgram>();
         int offset = 0;
@@ -147,7 +147,7 @@ IHasCreators
     /// </summary>
     public int MaxProgressiveCount => 100;
 
-    public async Task<(bool, List<ProvidableItemBase>)> GetProgressiveItemsListAsync(int start, int count, CancellationToken ctk = new CancellationToken())
+    public async Task<(bool, List<ProvidableItemBase>)> GetProgressiveItemsListAsync(int start, int count, CancellationToken ctk = default)
     {
         var result = await NeteaseProvider.Instance.RequestAsync(
             NeteaseApis.DjChannelProgramsApi,
@@ -174,7 +174,7 @@ IHasCreators
     /// <summary>
     /// 获取电台封面
     /// </summary>
-    public async Task<ResourceResultBase> GetCoverAsync(ImageResourceQualityTag? qualityTag = null, CancellationToken ctk = new CancellationToken())
+    public async Task<ResourceResultBase> GetCoverAsync(ImageResourceQualityTag? qualityTag = null, CancellationToken ctk = default)
     {
         var coverUrl = CoverUrl ?? "";
         if (string.IsNullOrEmpty(coverUrl))
@@ -218,7 +218,7 @@ IHasCreators
     /// <summary>
     /// 获取电台主播列表
     /// </summary>
-    public Task<List<PersonBase>?> GetCreatorsAsync(CancellationToken ctk = new CancellationToken())
+    public Task<List<PersonBase>?> GetCreatorsAsync(CancellationToken ctk = default)
     {
         if (Host != null)
             return Task.FromResult<List<PersonBase>?>(new List<PersonBase> { Host });

--- a/HyPlayer.NeteaseProvider/Models/NeteaseRadioChannel.cs
+++ b/HyPlayer.NeteaseProvider/Models/NeteaseRadioChannel.cs
@@ -1,4 +1,7 @@
-﻿using HyPlayer.NeteaseProvider.Constants;
+﻿using HyPlayer.NeteaseApi.ApiContracts;
+using HyPlayer.NeteaseApi.ApiContracts.DjChannel;
+using HyPlayer.NeteaseProvider.Constants;
+using HyPlayer.NeteaseProvider.Mappers;
 using HyPlayer.PlayCore.Abstraction.Interfaces.PlayListContainer;
 using HyPlayer.PlayCore.Abstraction.Interfaces.ProvidableItem;
 using HyPlayer.PlayCore.Abstraction.Models;
@@ -12,26 +15,216 @@ IHasCreators
 {
     public override string ProviderId => "ncm";
     public override string TypeId => NeteaseTypeIds.RadioChannel;
+
+    /// <summary>
+    /// 电台节目数量
+    /// </summary>
+    public int ProgramCount { get; set; }
+
+    /// <summary>
+    /// 创建时间戳 (毫秒)
+    /// </summary>
+    public long CreateTime { get; set; }
+
+    /// <summary>
+    /// 订阅人数
+    /// </summary>
+    public long SubscribedCount { get; set; }
+
+    /// <summary>
+    /// 电台封面 URL
+    /// </summary>
+    public string? CoverUrl { get; set; }
+
+    /// <summary>
+    /// 类别ID
+    /// </summary>
+    public int CategoryId { get; set; }
+
+    /// <summary>
+    /// 类别名称
+    /// </summary>
+    public string? Category { get; set; }
+
+    /// <summary>
+    /// 子类别ID
+    /// </summary>
+    public int SecondCategoryId { get; set; }
+
+    /// <summary>
+    /// 子类别名称
+    /// </summary>
+    public string? SecondCategory { get; set; }
+
+    /// <summary>
+    /// 点赞数
+    /// </summary>
+    public long LikedCount { get; set; }
+
+    /// <summary>
+    /// 评论数
+    /// </summary>
+    public long CommentCount { get; set; }
+
+    /// <summary>
+    /// 分享数
+    /// </summary>
+    public long ShareCount { get; set; }
+
+    /// <summary>
+    /// 播放数
+    /// </summary>
+    public long PlayCount { get; set; }
+
+    /// <summary>
+    /// 推荐文本
+    /// </summary>
+    public string? RecommendText { get; set; }
+
+    /// <summary>
+    /// 价格
+    /// </summary>
+    public float Price { get; set; }
+
+    /// <summary>
+    /// 是否已购买
+    /// </summary>
+    public bool Bought { get; set; }
+
+    /// <summary>
+    /// 最后一期节目创建时间
+    /// </summary>
+    public long LastProgramCreateTime { get; set; }
+
+    /// <summary>
+    /// 最后一期节目ID
+    /// </summary>
+    public string? LastProgramId { get; set; }
+
+    /// <summary>
+    /// 最后一期节目名称
+    /// </summary>
+    public string? LastProgramName { get; set; }
+
+    /// <summary>
+    /// 是否为高质量电台
+    /// </summary>
+    public bool IsHighQuality { get; set; }
+
+    /// <summary>
+    /// 是否已订阅
+    /// </summary>
+    public bool Subscribed { get; set; }
+
+    /// <summary>
+    /// 电台主播
+    /// </summary>
+    public NeteaseUser? Host { get; set; }
+
+    private NeteaseRadioProgram[]? _cachedPrograms;
+
+    /// <summary>
+    /// 获取所有节目
+    /// </summary>
     public override async Task<List<ProvidableItemBase>> GetAllItemsAsync(CancellationToken ctk = new CancellationToken())
     {
-        throw new NotImplementedException();
+        var programs = new List<NeteaseRadioProgram>();
+        int offset = 0;
+        const int pageSize = 100;
+        bool hasMore = true;
+
+        while (hasMore)
+        {
+            var (more, items) = await GetProgressiveItemsListAsync(offset, pageSize, ctk);
+            programs.AddRange(items.Cast<NeteaseRadioProgram>());
+            hasMore = more;
+            offset += pageSize;
+        }
+
+        return programs.Cast<ProvidableItemBase>().ToList();
     }
 
+    /// <summary>
+    /// 获取分页节目列表
+    /// </summary>
     public int MaxProgressiveCount => 100;
+
     public async Task<(bool, List<ProvidableItemBase>)> GetProgressiveItemsListAsync(int start, int count, CancellationToken ctk = new CancellationToken())
     {
-        throw new NotImplementedException();
+        var result = await NeteaseProvider.Instance.RequestAsync(
+            NeteaseApis.DjChannelProgramsApi,
+            new DjChannelProgramsRequest
+            {
+                RadioId = ActualId!,
+                Limit = count,
+                Offset = start,
+                Asc = false
+            }, ctk);
+
+        return result.Match(
+            success =>
+            {
+                var programs = success.Data?.Programs?
+                    .Select(p => (ProvidableItemBase)p.MapToNeteaseRadioProgram())
+                    .ToList() ?? new List<ProvidableItemBase>();
+                bool hasMore = success.Data?.More ?? false;
+                return (hasMore, programs);
+            },
+            error => (false, new List<ProvidableItemBase>()));
     }
 
+    /// <summary>
+    /// 获取电台封面
+    /// </summary>
     public async Task<ResourceResultBase> GetCoverAsync(ImageResourceQualityTag? qualityTag = null, CancellationToken ctk = new CancellationToken())
     {
-        throw new NotImplementedException();
+        var coverUrl = CoverUrl ?? "";
+        if (string.IsNullOrEmpty(coverUrl))
+        {
+            return new NeteaseImageResourceResult()
+            {
+                ExternalException = new Exception("No cover URL available"),
+                ResourceStatus = ResourceStatus.Success,
+                Uri = null!
+            };
+        }
+
+        if (qualityTag is NeteaseImageResourceQualityTag neteaseImageResourceQualityTag)
+        {
+            return new NeteaseImageResourceResult()
+            {
+                ExternalException = null,
+                ResourceStatus = ResourceStatus.Success,
+                Uri = new Uri($"{coverUrl}?{neteaseImageResourceQualityTag}")
+            };
+        }
+
+        return new NeteaseImageResourceResult()
+        {
+            ExternalException = null,
+            ResourceStatus = ResourceStatus.Success,
+            Uri = new Uri(coverUrl)
+        };
     }
 
+    /// <summary>
+    /// 电台描述
+    /// </summary>
     public string? Description { get; set; }
+
+    /// <summary>
+    /// 主播名称列表
+    /// </summary>
     public List<string>? CreatorList { get; init; }
-    public async Task<List<PersonBase>?> GetCreatorsAsync(CancellationToken ctk = new CancellationToken())
+
+    /// <summary>
+    /// 获取电台主播列表
+    /// </summary>
+    public Task<List<PersonBase>?> GetCreatorsAsync(CancellationToken ctk = new CancellationToken())
     {
-        throw new NotImplementedException();
+        if (Host != null)
+            return Task.FromResult<List<PersonBase>?>(new List<PersonBase> { Host });
+
+        return Task.FromResult<List<PersonBase>?>(null);
     }
 }

--- a/HyPlayer.NeteaseProvider/Models/NeteaseRadioChannel.cs
+++ b/HyPlayer.NeteaseProvider/Models/NeteaseRadioChannel.cs
@@ -121,8 +121,6 @@ IHasCreators
     /// </summary>
     public NeteaseUser? Host { get; set; }
 
-    private NeteaseRadioProgram[]? _cachedPrograms;
-
     /// <summary>
     /// 获取所有节目
     /// </summary>

--- a/HyPlayer.NeteaseProvider/Models/NeteaseRadioProgram.cs
+++ b/HyPlayer.NeteaseProvider/Models/NeteaseRadioProgram.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseProvider.Constants;
+ï»¿using HyPlayer.NeteaseProvider.Constants;
 using HyPlayer.PlayCore.Abstraction.Interfaces.PlayListContainer;
 using HyPlayer.PlayCore.Abstraction.Interfaces.ProvidableItem;
 using HyPlayer.PlayCore.Abstraction.Models;
@@ -14,82 +14,82 @@ public class NeteaseRadioProgram : SingleSongBase, IHasCover, IHasDescription, I
     public override string TypeId => NeteaseTypeIds.RadioProgram;
 
     /// <summary>
-    /// ½ÚÄ¿·âÃæ URL
+    /// èŠ‚ç›®å°é¢ URL
     /// </summary>
     public string? PictureUrl { get; set; }
 
     /// <summary>
-    /// ½ÚÄ¿·âÃæ URL (±¸ÓÃ)
+    /// èŠ‚ç›®å°é¢ URL (å¤‡ç”¨)
     /// </summary>
     public string? CoverUrl { get; set; }
 
     /// <summary>
-    /// ½ÚÄ¿Ê±³¤
+    /// èŠ‚ç›®æ—¶é•¿
     /// </summary>
     public long ProgramDuration { get; set; }
 
     /// <summary>
-    /// ½ÚÄ¿ËùÊôµçÌ¨
+    /// èŠ‚ç›®æ‰€å±ç”µå°
     /// </summary>
     public NeteaseRadioChannel? RadioChannel { get; set; }
 
     /// <summary>
-    /// ½ÚÄ¿Ö÷¸èÇú
+    /// èŠ‚ç›®ä¸»æ­Œæ›²
     /// </summary>
     public NeteaseSong? MainSong { get; set; }
 
     /// <summary>
-    /// ÊÇ·ñÒÑ¹ºÂò
+    /// æ˜¯å¦å·²è´­ä¹°
     /// </summary>
     public bool Bought { get; set; }
 
     /// <summary>
-    /// ¼àÌıÈËÊı
+    /// ç›‘å¬äººæ•°
     /// </summary>
     public long ListenerCount { get; set; }
 
     /// <summary>
-    /// ¶©ÔÄÈËÊı
+    /// è®¢é˜…äººæ•°
     /// </summary>
     public long SubscribedCount { get; set; }
 
     /// <summary>
-    /// ÆÀÂÛÊı
+    /// è¯„è®ºæ•°
     /// </summary>
     public long CommentCount { get; set; }
 
     /// <summary>
-    /// ·ÖÏíÊı
+    /// åˆ†äº«æ•°
     /// </summary>
     public long ShareCount { get; set; }
 
     /// <summary>
-    /// µãÔŞÊı
+    /// ç‚¹èµæ•°
     /// </summary>
     public long LikedCount { get; set; }
 
     /// <summary>
-    /// ´´½¨Ê±¼ä´Á (ºÁÃë)
+    /// åˆ›å»ºæ—¶é—´æˆ³ (æ¯«ç§’)
     /// </summary>
     public long CreateTime { get; set; }
 
     /// <summary>
-    /// ÆÚÊı
+    /// æœŸæ•°
     /// </summary>
     public int SerialNum { get; set; }
 
     /// <summary>
-    /// ½ÚÄ¿ÃèÊö
+    /// èŠ‚ç›®æè¿°
     /// </summary>
     public string? Description { get; set; }
 
     /// <summary>
-    /// Ö÷²¥ÁĞ±í
+    /// ä¸»æ’­åˆ—è¡¨
     /// </summary>
     public List<string>? CreatorList { get; init; }
 
     /// <summary>
-    /// Ö÷²¥ĞÅÏ¢
+    /// ä¸»æ’­ä¿¡æ¯
     /// </summary>
     public NeteaseUser? Host { get; set; }
 

--- a/HyPlayer.NeteaseProvider/Models/NeteaseRadioProgram.cs
+++ b/HyPlayer.NeteaseProvider/Models/NeteaseRadioProgram.cs
@@ -84,11 +84,6 @@ public class NeteaseRadioProgram : SingleSongBase, IHasCover, IHasDescription, I
     public string? Description { get; set; }
 
     /// <summary>
-    /// 主播列表
-    /// </summary>
-    public List<string>? CreatorList { get; init; }
-
-    /// <summary>
     /// 主播信息
     /// </summary>
     public NeteaseUser? Host { get; set; }

--- a/HyPlayer.NeteaseProvider/Models/NeteaseRadioProgram.cs
+++ b/HyPlayer.NeteaseProvider/Models/NeteaseRadioProgram.cs
@@ -88,7 +88,7 @@ public class NeteaseRadioProgram : SingleSongBase, IHasCover, IHasDescription, I
     /// </summary>
     public NeteaseUser? Host { get; set; }
 
-    public override Task<List<PersonBase>?> GetCreatorsAsync(CancellationToken ctk = new())
+    public override Task<List<PersonBase>?> GetCreatorsAsync(CancellationToken ctk = default)
     {
         if (Host != null)
             return Task.FromResult<List<PersonBase>?>(new List<PersonBase> { Host });

--- a/HyPlayer.NeteaseProvider/Models/NeteaseRadioProgram.cs
+++ b/HyPlayer.NeteaseProvider/Models/NeteaseRadioProgram.cs
@@ -1,0 +1,135 @@
+using HyPlayer.NeteaseProvider.Constants;
+using HyPlayer.PlayCore.Abstraction.Interfaces.PlayListContainer;
+using HyPlayer.PlayCore.Abstraction.Interfaces.ProvidableItem;
+using HyPlayer.PlayCore.Abstraction.Models;
+using HyPlayer.PlayCore.Abstraction.Models.Containers;
+using HyPlayer.PlayCore.Abstraction.Models.Resources;
+using HyPlayer.PlayCore.Abstraction.Models.SingleItems;
+
+namespace HyPlayer.NeteaseProvider.Models;
+
+public class NeteaseRadioProgram : SingleSongBase, IHasCover, IHasDescription, IHasCreators
+{
+    public override string ProviderId => "ncm";
+    public override string TypeId => NeteaseTypeIds.RadioProgram;
+
+    /// <summary>
+    /// 节目封面 URL
+    /// </summary>
+    public string? PictureUrl { get; set; }
+
+    /// <summary>
+    /// 节目封面 URL (备用)
+    /// </summary>
+    public string? CoverUrl { get; set; }
+
+    /// <summary>
+    /// 节目时长
+    /// </summary>
+    public long ProgramDuration { get; set; }
+
+    /// <summary>
+    /// 节目所属电台
+    /// </summary>
+    public NeteaseRadioChannel? RadioChannel { get; set; }
+
+    /// <summary>
+    /// 节目主歌曲
+    /// </summary>
+    public NeteaseSong? MainSong { get; set; }
+
+    /// <summary>
+    /// 是否已购买
+    /// </summary>
+    public bool Bought { get; set; }
+
+    /// <summary>
+    /// 监听人数
+    /// </summary>
+    public long ListenerCount { get; set; }
+
+    /// <summary>
+    /// 订阅人数
+    /// </summary>
+    public long SubscribedCount { get; set; }
+
+    /// <summary>
+    /// 评论数
+    /// </summary>
+    public long CommentCount { get; set; }
+
+    /// <summary>
+    /// 分享数
+    /// </summary>
+    public long ShareCount { get; set; }
+
+    /// <summary>
+    /// 点赞数
+    /// </summary>
+    public long LikedCount { get; set; }
+
+    /// <summary>
+    /// 创建时间戳 (毫秒)
+    /// </summary>
+    public long CreateTime { get; set; }
+
+    /// <summary>
+    /// 期数
+    /// </summary>
+    public int SerialNum { get; set; }
+
+    /// <summary>
+    /// 节目描述
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// 主播列表
+    /// </summary>
+    public List<string>? CreatorList { get; init; }
+
+    /// <summary>
+    /// 主播信息
+    /// </summary>
+    public NeteaseUser? Host { get; set; }
+
+    public override Task<List<PersonBase>?> GetCreatorsAsync(CancellationToken ctk = new())
+    {
+        if (Host != null)
+            return Task.FromResult<List<PersonBase>?>(new List<PersonBase> { Host });
+
+        return Task.FromResult<List<PersonBase>?>(null);
+    }
+
+    public Task<ResourceResultBase> GetCoverAsync(ImageResourceQualityTag? qualityTag = null, CancellationToken ctk = default)
+    {
+        var coverUrl = CoverUrl ?? PictureUrl ?? "";
+        if (string.IsNullOrEmpty(coverUrl))
+        {
+            return Task.FromResult<ResourceResultBase>(new NeteaseImageResourceResult()
+            {
+                ExternalException = new Exception("No cover URL available"),
+                ResourceStatus = ResourceStatus.Success,
+                Uri = null!
+            });
+        }
+
+        if (qualityTag is NeteaseImageResourceQualityTag neteaseImageResourceQualityTag)
+        {
+            var result = new NeteaseImageResourceResult()
+            {
+                ExternalException = null,
+                ResourceStatus = ResourceStatus.Success,
+                Uri = new Uri($"{coverUrl}?{neteaseImageResourceQualityTag}")
+            };
+            return Task.FromResult(result as ResourceResultBase);
+        }
+
+        return Task.FromResult(new NeteaseImageResourceResult()
+        {
+            ExternalException = null,
+            ResourceStatus = ResourceStatus.Success,
+            Uri = new Uri(coverUrl)
+        } as ResourceResultBase);
+    }
+}

--- a/HyPlayer.NeteaseProvider/Models/NeteaseRawLyricInfo.cs
+++ b/HyPlayer.NeteaseProvider/Models/NeteaseRawLyricInfo.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseProvider.Constants;
+﻿using HyPlayer.NeteaseProvider.Constants;
 using HyPlayer.PlayCore.Abstraction.Models;
 using HyPlayer.PlayCore.Abstraction.Models.Lyric;
 using HyPlayer.PlayCore.Abstraction.Models.Resources;

--- a/HyPlayer.NeteaseProvider/Models/NeteaseSearchContainer.cs
+++ b/HyPlayer.NeteaseProvider/Models/NeteaseSearchContainer.cs
@@ -24,12 +24,12 @@ public class NeteaseSearchContainer : LinerContainerBase, IProgressiveLoadingCon
         Name = "搜索结果";
     }
 
-    public override async Task<List<ProvidableItemBase>> GetAllItemsAsync(CancellationToken ctk = new())
+    public override async Task<List<ProvidableItemBase>> GetAllItemsAsync(CancellationToken ctk = default)
     {
         return (await GetProgressiveItemsListAsync(0, MaxProgressiveCount, ctk)).Item2;
     }
 
-    public async Task<(bool, List<ProvidableItemBase>)> GetProgressiveItemsListAsync(int start, int count, CancellationToken ctk = new())
+    public async Task<(bool, List<ProvidableItemBase>)> GetProgressiveItemsListAsync(int start, int count, CancellationToken ctk = default)
     {
         switch (SearchTypeId)
         {

--- a/HyPlayer.NeteaseProvider/Models/NeteaseSearchContainer.cs
+++ b/HyPlayer.NeteaseProvider/Models/NeteaseSearchContainer.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseApi.ApiContracts;
+﻿using HyPlayer.NeteaseApi.ApiContracts;
 using HyPlayer.NeteaseApi.ApiContracts.Recommend;
 using HyPlayer.NeteaseApi.Bases;
 using HyPlayer.NeteaseApi.Models;

--- a/HyPlayer.NeteaseProvider/Models/NeteaseSong.cs
+++ b/HyPlayer.NeteaseProvider/Models/NeteaseSong.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseProvider.Constants;
+﻿using HyPlayer.NeteaseProvider.Constants;
 using HyPlayer.PlayCore.Abstraction.Interfaces.ProvidableItem;
 using HyPlayer.PlayCore.Abstraction.Models;
 using HyPlayer.PlayCore.Abstraction.Models.Containers;

--- a/HyPlayer.NeteaseProvider/Models/NeteaseSong.cs
+++ b/HyPlayer.NeteaseProvider/Models/NeteaseSong.cs
@@ -21,7 +21,7 @@ public class NeteaseSong : SingleSongBase, IHasTranslation, IHasCover
 
     public required List<PersonBase>? Artists { get; init; }
 
-    public override Task<List<PersonBase>?> GetCreatorsAsync(CancellationToken ctk = new())
+    public override Task<List<PersonBase>?> GetCreatorsAsync(CancellationToken ctk = default)
     {
         return Task.FromResult(Artists);
     }

--- a/HyPlayer.NeteaseProvider/Models/NeteaseUser.cs
+++ b/HyPlayer.NeteaseProvider/Models/NeteaseUser.cs
@@ -21,7 +21,7 @@ public class NeteaseUser : PersonBase, IHasCover, IHasDescription
 
     public string? AvatarUrl { get; set; }
 
-    public override async Task<List<ContainerBase>> GetSubContainerAsync(CancellationToken ctk = new())
+    public override async Task<List<ContainerBase>> GetSubContainerAsync(CancellationToken ctk = default)
     {
         var results = await NeteaseProvider.Instance.RequestAsync(NeteaseApis.UserPlaylistApi,
                                                     new UserPlaylistRequest

--- a/HyPlayer.NeteaseProvider/Models/NeteaseUser.cs
+++ b/HyPlayer.NeteaseProvider/Models/NeteaseUser.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseApi.ApiContracts;
+﻿using HyPlayer.NeteaseApi.ApiContracts;
 using HyPlayer.NeteaseApi.ApiContracts.User;
 using HyPlayer.NeteaseProvider.Constants;
 using HyPlayer.NeteaseProvider.Mappers;

--- a/HyPlayer.NeteaseProvider/NeteaseProvider.cs
+++ b/HyPlayer.NeteaseProvider/NeteaseProvider.cs
@@ -16,6 +16,7 @@ using HyPlayer.PlayCore.Abstraction.Models.Lyric;
 using HyPlayer.PlayCore.Abstraction.Models.Resources;
 using HyPlayer.PlayCore.Abstraction.Models.SingleItems;
 using HyPlayer.NeteaseApi.Extensions;
+using HyPlayer.NeteaseApi.ApiContracts.DjChannel;
 
 namespace HyPlayer.NeteaseProvider;
 
@@ -323,7 +324,11 @@ public class NeteaseProvider : ProviderBase,
                                    PlaylistId = inProviderId.Substring(2)
                                }, ctk);
         }
-        // TODO
+
+        else if (inProviderId.StartsWith(NeteaseTypeIds.User))
+        {
+            // TODO: Implement follow user API
+        }
     }
 
     public async Task<List<string>> GetLikedProvidableIdsAsync(string typeId, CancellationToken ctk = new())

--- a/HyPlayer.NeteaseProvider/NeteaseProvider.cs
+++ b/HyPlayer.NeteaseProvider/NeteaseProvider.cs
@@ -378,7 +378,7 @@ public class NeteaseProvider : ProviderBase,
                 await RequestAsync(NeteaseApis.ArtistUnsubscribeApi,
                     new ArtistUnsubscribeRequest()
                     {
-                        ArtistIds = new[] { lid }
+                        ArtistIds = [lid]
                     }, ctk);
             }
         }

--- a/HyPlayer.NeteaseProvider/NeteaseProvider.cs
+++ b/HyPlayer.NeteaseProvider/NeteaseProvider.cs
@@ -162,7 +162,7 @@ public class NeteaseProvider : ProviderBase,
     }
 
     public async Task<bool> LoginEmailAsync(string email, string password, bool isMd5 = false,
-                                            CancellationToken ctk = new())
+                                            CancellationToken ctk = default)
     {
         var request = new LoginEmailRequest()
         {
@@ -184,7 +184,7 @@ public class NeteaseProvider : ProviderBase,
     }
 
     public async Task<bool> LoginCellphoneAsync(string cellphone, string password, bool isMd5 = false,
-                                                CancellationToken ctk = new())
+                                                CancellationToken ctk = default)
     {
         var request = new LoginCellphoneRequest()
         {
@@ -206,7 +206,7 @@ public class NeteaseProvider : ProviderBase,
     }
 
 
-    public async Task<List<RawLyricInfo>> GetLyricInfoAsync(SingleSongBase song, CancellationToken ctk = new())
+    public async Task<List<RawLyricInfo>> GetLyricInfoAsync(SingleSongBase song, CancellationToken ctk = default)
     {
         if (song.ActualId == null) throw new ArgumentNullException();
         var results = await RequestAsync(NeteaseApis.LyricApi, new LyricRequest() { Id = song.ActualId }, ctk);
@@ -217,7 +217,7 @@ public class NeteaseProvider : ProviderBase,
     }
 
     public async Task<MusicResourceBase?> GetMusicResourceAsync(SingleSongBase song, ResourceQualityTag qualityTag,
-                                                                CancellationToken ctk = new())
+                                                                CancellationToken ctk = default)
     {
         var quality = "exhigh";
         if (qualityTag is NeteaseMusicQualityTag neteaseMusicQualityTag)
@@ -253,7 +253,7 @@ public class NeteaseProvider : ProviderBase,
         );
     }
 
-    public async Task LikeProvidableItemAsync(string inProviderId, string? targetId, CancellationToken ctk = new())
+    public async Task LikeProvidableItemAsync(string inProviderId, string? targetId, CancellationToken ctk = default)
     {
         if (inProviderId.StartsWith(NeteaseTypeIds.SingleSong))
         {
@@ -333,7 +333,7 @@ public class NeteaseProvider : ProviderBase,
         }
     }
 
-    public async Task UnlikeProvidableItemAsync(string inProviderId, string? targetId, CancellationToken ctk = new())
+    public async Task UnlikeProvidableItemAsync(string inProviderId, string? targetId, CancellationToken ctk = default)
     {
         if (inProviderId.StartsWith(NeteaseTypeIds.SingleSong))
         {
@@ -418,7 +418,7 @@ public class NeteaseProvider : ProviderBase,
         }
     }
 
-    public async Task<List<string>> GetLikedProvidableIdsAsync(string typeId, CancellationToken ctk = new())
+    public async Task<List<string>> GetLikedProvidableIdsAsync(string typeId, CancellationToken ctk = default)
     {
         var result = await RequestAsync(NeteaseApis.LikelistApi, new LikelistRequest()
         {
@@ -431,7 +431,7 @@ public class NeteaseProvider : ProviderBase,
 
 
     public async Task<ProvidableItemBase?> GetProvidableItemByIdAsync(string inProviderId,
-                                                                      CancellationToken ctk = new())
+                                                                      CancellationToken ctk = default)
     {
         var typeId = inProviderId.Substring(0, 2);
         var actualId = inProviderId.Substring(2);
@@ -447,7 +447,7 @@ public class NeteaseProvider : ProviderBase,
     }
 
     public async Task<List<ProvidableItemBase>> GetProvidableItemsRangeAsync(
-        List<string> inProviderIds, CancellationToken ctk = new())
+        List<string> inProviderIds, CancellationToken ctk = default)
     {
         if (inProviderIds.Count == 0) return new List<ProvidableItemBase>();
         var grouped = inProviderIds.GroupBy(t => t.Substring(0, 2)).ToList();
@@ -526,7 +526,7 @@ public class NeteaseProvider : ProviderBase,
     #endregion
 
     public Task<ContainerBase> SearchProvidableItemsAsync(string keyword, string typeId,
-                                                                 CancellationToken ctk = new())
+                                                                 CancellationToken ctk = default)
     {
         return Task.FromResult(new NeteaseSearchContainer
         {
@@ -537,7 +537,7 @@ public class NeteaseProvider : ProviderBase,
         } as ContainerBase);
     }
 
-    public Task<ContainerBase?> GetStoredItemsAsync(string typeId, CancellationToken ctk = new())
+    public Task<ContainerBase?> GetStoredItemsAsync(string typeId, CancellationToken ctk = default)
     {
         switch (typeId)
         {
@@ -548,7 +548,7 @@ public class NeteaseProvider : ProviderBase,
         }
     }
 
-    public Task<ContainerBase> GetRecommendationAsync(string? typeId = null, CancellationToken ctk = new())
+    public Task<ContainerBase> GetRecommendationAsync(string? typeId = null, CancellationToken ctk = default)
     {
         // ReSharper disable once ConvertIfStatementToSwitchStatement
         if (typeId == NeteaseTypeIds.Playlist) // 推荐歌单

--- a/HyPlayer.NeteaseProvider/NeteaseProvider.cs
+++ b/HyPlayer.NeteaseProvider/NeteaseProvider.cs
@@ -328,8 +328,7 @@ public class NeteaseProvider : ProviderBase,
             await RequestAsync(NeteaseApis.UserFollowApi,
                 new UserFollowRequest()
                 {
-                    Id = inProviderId.Substring(2),
-                    IsFollow = true
+                    Id = inProviderId.Substring(2)
                 }, ctk);
         }
     }
@@ -397,7 +396,7 @@ public class NeteaseProvider : ProviderBase,
             await RequestAsync(NeteaseApis.VideoUnsubscribeApi,
                 new VideoUnsubscribeRequest()
                 {
-                    VideoIds = new[] { inProviderId.Substring(2) }
+                    IdList = [ inProviderId.Substring(2)]
                 }, ctk);
         }
         else if (inProviderId.StartsWith(NeteaseTypeIds.RadioChannel))
@@ -411,11 +410,10 @@ public class NeteaseProvider : ProviderBase,
         }
         else if (inProviderId.StartsWith(NeteaseTypeIds.User))
         {
-            await RequestAsync(NeteaseApis.UserFollowApi,
-                new UserFollowRequest()
+            await RequestAsync(NeteaseApis.UserUnfollowApi,
+                new UserUnfollowRequest()
                 {
-                    Id = inProviderId.Substring(2),
-                    IsFollow = false
+                    Id = inProviderId.Substring(2)
                 }, ctk);
         }
     }

--- a/HyPlayer.NeteaseProvider/NeteaseProvider.cs
+++ b/HyPlayer.NeteaseProvider/NeteaseProvider.cs
@@ -2,6 +2,10 @@ using HyPlayer.NeteaseApi;
 using HyPlayer.NeteaseApi.ApiContracts;
 using HyPlayer.NeteaseApi.ApiContracts.Login;
 using HyPlayer.NeteaseApi.ApiContracts.Playlist;
+using HyPlayer.NeteaseApi.ApiContracts.Artist;
+using HyPlayer.NeteaseApi.ApiContracts.Album;
+using HyPlayer.NeteaseApi.ApiContracts.Video;
+using HyPlayer.NeteaseApi.ApiContracts.User;
 using HyPlayer.NeteaseApi.ApiContracts.Recommend;
 using HyPlayer.NeteaseApi.ApiContracts.Song;
 using HyPlayer.NeteaseApi.Bases;
@@ -285,7 +289,49 @@ public class NeteaseProvider : ProviderBase,
                                    PlaylistId = inProviderId.Substring(2)
                                }, ctk);
         }
-        // TODO
+        else if (inProviderId.StartsWith(NeteaseTypeIds.Artist))
+        {
+            await RequestAsync(NeteaseApis.ArtistSubscribeApi,
+                new ArtistSubscribeRequest()
+                {
+                    ArtistId = inProviderId.Substring(2)
+                }, ctk);
+        }
+        else if (inProviderId.StartsWith(NeteaseTypeIds.Album))
+        {
+            await RequestAsync(NeteaseApis.AlbumSubscribeApi,
+                new AlbumSubscribeRequest()
+                {
+                    Id = inProviderId.Substring(2),
+                    IsSubscribe = true
+                }, ctk);
+        }
+        else if (inProviderId.StartsWith(NeteaseTypeIds.Mv))
+        {
+            await RequestAsync(NeteaseApis.VideoSubscribeApi,
+                new VideoSubscribeRequest()
+                {
+                    MvId = inProviderId.Substring(2)
+                }, ctk);
+        }
+        else if (inProviderId.StartsWith(NeteaseTypeIds.RadioChannel))
+        {
+            await RequestAsync(NeteaseApis.DjChannelSubscribeApi,
+                new DjChannelSubscribeRequest()
+                {
+                    Id = inProviderId.Substring(2),
+                    IsSubscribe = true
+                }, ctk);
+        }
+        else if (inProviderId.StartsWith(NeteaseTypeIds.User))
+        {
+            await RequestAsync(NeteaseApis.UserFollowApi,
+                new UserFollowRequest()
+                {
+                    Id = inProviderId.Substring(2),
+                    IsFollow = true
+                }, ctk);
+        }
     }
 
     public async Task UnlikeProvidableItemAsync(string inProviderId, string? targetId, CancellationToken ctk = new())
@@ -325,9 +371,52 @@ public class NeteaseProvider : ProviderBase,
                                }, ctk);
         }
 
+        else if (inProviderId.StartsWith(NeteaseTypeIds.Artist))
+        {
+            var id = inProviderId.Substring(2);
+            if (long.TryParse(id, out var lid))
+            {
+                await RequestAsync(NeteaseApis.ArtistUnsubscribeApi,
+                    new ArtistUnsubscribeRequest()
+                    {
+                        ArtistIds = new[] { lid }
+                    }, ctk);
+            }
+        }
+        else if (inProviderId.StartsWith(NeteaseTypeIds.Album))
+        {
+            await RequestAsync(NeteaseApis.AlbumSubscribeApi,
+                new AlbumSubscribeRequest()
+                {
+                    Id = inProviderId.Substring(2),
+                    IsSubscribe = false
+                }, ctk);
+        }
+        else if (inProviderId.StartsWith(NeteaseTypeIds.Mv))
+        {
+            await RequestAsync(NeteaseApis.VideoUnsubscribeApi,
+                new VideoUnsubscribeRequest()
+                {
+                    VideoIds = new[] { inProviderId.Substring(2) }
+                }, ctk);
+        }
+        else if (inProviderId.StartsWith(NeteaseTypeIds.RadioChannel))
+        {
+            await RequestAsync(NeteaseApis.DjChannelSubscribeApi,
+                new DjChannelSubscribeRequest()
+                {
+                    Id = inProviderId.Substring(2),
+                    IsSubscribe = false
+                }, ctk);
+        }
         else if (inProviderId.StartsWith(NeteaseTypeIds.User))
         {
-            // TODO: Implement follow user API
+            await RequestAsync(NeteaseApis.UserFollowApi,
+                new UserFollowRequest()
+                {
+                    Id = inProviderId.Substring(2),
+                    IsFollow = false
+                }, ctk);
         }
     }
 

--- a/HyPlayer.NeteaseProvider/NeteaseProvider.cs
+++ b/HyPlayer.NeteaseProvider/NeteaseProvider.cs
@@ -1,4 +1,4 @@
-using HyPlayer.NeteaseApi;
+﻿using HyPlayer.NeteaseApi;
 using HyPlayer.NeteaseApi.ApiContracts;
 using HyPlayer.NeteaseApi.ApiContracts.Login;
 using HyPlayer.NeteaseApi.ApiContracts.Playlist;

--- a/README.md
+++ b/README.md
@@ -70,7 +70,18 @@ High-level provider implementing HyPlayer provider abstraction for seamless inte
 
 ## Building
 
-Requires `.NET SDK 10.0.0` or later .
+Requires `.NET SDK 10.0.0` or later (as specified in `global.json`).
+
+```
+# Build all projects
+dotnet build
+
+# Build specific project
+dotnet build HyPlayer.NeteaseProvider/HyPlayer.NeteaseProvider.csproj
+
+# Run tests
+dotnet test
+```
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,93 @@
+﻿# HyPlayer.NeteaseProvider
+
+[![NuGet Publish](https://github.com/HyPlayer/HyPlayer.NeteaseProvider/actions/workflows/nuget-push.yml/badge.svg)](https://github.com/HyPlayer/HyPlayer.NeteaseProvider/actions/workflows/nuget-push.yml)
+[![License](https://img.shields.io/github/license/HyPlayer/HyPlayer.NeteaseProvider)](LICENSE)
+
+A comprehensive .NET provider for Netease Cloud Music API integration with HyPlayer ecosystem.
+
+## Overview
+
+HyPlayer.NeteaseProvider is a modern, type-safe provider library for integrating Netease Cloud Music services with the HyPlayer music player framework. It consists of two main components:
+
+- **HyPlayer.NeteaseApi** - Low-level API wrapper for Netease Cloud Music endpoints
+- **HyPlayer.NeteaseProvider** - High-level provider implementation for HyPlayer integration
+
+## Features
+
+- Multi-target support: `.NET Standard 2.0` and `.NET 9.0`
+- Type-safe API contracts with automatic JSON serialization
+- AOT (Ahead-of-Time) compatible for .NET 9.0+
+- Async/await support throughout
+- Comprehensive Netease API coverage
+- Integration with HyPlayer.PlayCore abstraction layer
+- Entity caching with Depository abstraction
+
+
+## Getting Started
+
+### Installation
+
+Install the NuGet package:
+
+` dotnet add package HyPlayer.NeteaseProvider `
+
+This will automatically include the `HyPlayer.NeteaseApi` dependency.
+
+### Prerequisites
+
+- `.NET Standard 2.0` or higher
+- `.NET 9.0` or higher (for latest features and AOT support)
+
+## Components
+
+### HyPlayer.NeteaseApi (v0.1.0)
+
+Low-level API wrapper providing direct access to Netease Cloud Music endpoints.
+
+**Key Features:**
+- RESTful API contract definitions
+- Automatic JSON serialization with source-generated serialization context
+- Support for multiple authentication methods
+- Comprehensive error handling
+
+**Dependencies:**
+- System.Text.Json v10.0.1
+
+### HyPlayer.NeteaseProvider (v0.0.11)
+
+High-level provider implementing HyPlayer provider abstraction for seamless integration.
+
+**Key Features:**
+- HyPlayer.PlayCore abstraction implementation
+- Entity repository pattern with Depository.Abstraction
+- Radio channel APIs support
+- Song, playlist, and album management
+
+**Dependencies:**
+- HyPlayer.PlayCore.Abstraction v0.1.4
+- Depository.Abstraction v3.2.0
+- HyPlayer.NeteaseApi
+
+## Building
+
+Requires `.NET SDK 10.0.0` or later .
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+## License
+
+This project is licensed under the [License](LICENSE) - see the LICENSE file for details.
+
+## Related Projects
+
+- [HyPlayer](https://github.com/HyPlayer/HyPlayer) - Main music player application
+- [HyPlayer.PlayCore](https://github.com/HyPlayer/HyPlayer.PlayCore) - Core playback abstraction
+- [Depository](https://github.com/HyPlayer/Depository) - Entity repository framework
+
+## Support
+
+For issues, feature requests, or questions, please visit the [GitHub Issues](https://github.com/HyPlayer/HyPlayer.NeteaseProvider/issues) page.
+
+---


### PR DESCRIPTION
PR Classification
本次 PR 主要为功能扩展和文档增强，涉及 API 新增、模型完善、Provider 逻辑优化及项目结构调整。

PR Summary
本次更新显著增强了 HyPlayer.NeteaseProvider 的资源订阅管理能力，完善了电台频道与节目模型，并提升了文档与开发者体验。

NeteaseProvider.cs：实现了对艺术家、专辑、MV、电台频道、用户等资源的订阅与取消订阅逻辑，自动调用对应 API。
新增 ArtistSubscribeApi、ArtistUnsubscribeApi、VideoSubscribeApi、VideoUnsubscribeApi、DjChannelSubscribeApi、UserFollowApi 等，支持批量订阅/取消订阅操作。
NeteaseRadioChannel.cs 和 NeteaseRadioProgram.cs：完善模型属性，支持节目分页加载、封面获取、主播信息等功能。
DjRadioProgramToNeteaseRadioProgramMapper.cs 和 RadioChannelToNeteaseRadioChannelMapper.cs：实现 DTO 到 Provider 实体的自动映射。
新增 README.md，详细介绍项目功能、安装方法、依赖和贡献指南。